### PR TITLE
feat(api-http): add auth and role guard decorators

### DIFF
--- a/apps/api/restaurants/tests.py
+++ b/apps/api/restaurants/tests.py
@@ -1,3 +1,159 @@
-from django.test import TestCase
+"""Tests for restaurant endpoints with guards and authentication."""
 
-# Create your tests here.
+import uuid
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from restaurants.models import Category, Restaurant
+from users.models import UserRole
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_user(*, role: str = UserRole.USER):
+    suffix = uuid.uuid4().hex[:8]
+    user_model = get_user_model()
+    return user_model.objects.create_user(
+        email=f"restaurant-{role}-{suffix}@example.com",
+        username=f"restaurant-{role}-{suffix}",
+        password="test-password-123",
+        display_name=f"{role.title()} {suffix}",
+        role=role,
+    )
+
+
+def _create_category():
+    suffix = uuid.uuid4().hex[:8]
+    return Category.objects.create(
+        name=f"Test Category {suffix}",
+        description="Category for tests",
+    )
+
+
+def _create_restaurant(owner=None, slug=None):
+    if owner is None:
+        owner = _create_user(role=UserRole.OWNER)
+    category = _create_category()
+    suffix = uuid.uuid4().hex[:8]
+    return Restaurant.objects.create(
+        name=f"Test Restaurant {suffix}",
+        slug=slug or f"test-restaurant-{suffix}",
+        description="A test restaurant",
+        category=category,
+        owner=owner,
+        address_line1="Test Street 123",
+        city="Istanbul",
+        district="Besiktas",
+        price_range="2",
+    )
+
+
+def test_restaurant_list_no_auth_required():
+    """GET /restaurants/ should not require authentication."""
+    client = Client()
+
+    response = client.get("/api/v1/restaurants/")
+
+    assert response.status_code == 200
+    assert "data" in response.json()
+
+
+def test_restaurant_detail_no_auth_required():
+    """GET /restaurants/{slug}/ should not require authentication."""
+    client = Client()
+    restaurant = _create_restaurant()
+
+    try:
+        response = client.get(f"/api/v1/restaurants/{restaurant.slug}/")
+
+        assert response.status_code == 200
+        assert "data" in response.json()
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        restaurant.owner.delete()
+
+
+def test_restaurant_delete_requires_authentication():
+    """DELETE /restaurants/{slug}/ requires authentication."""
+    client = Client()
+    restaurant = _create_restaurant()
+
+    try:
+        response = client.delete(f"/api/v1/restaurants/{restaurant.slug}/")
+
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "auth_required"
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        restaurant.owner.delete()
+
+
+def test_restaurant_delete_requires_admin_role():
+    """DELETE /restaurants/{slug}/ requires admin role."""
+    client = Client()
+    regular_user = _create_user(role=UserRole.USER)
+    restaurant = _create_restaurant()
+
+    try:
+        client.force_login(regular_user)
+        response = client.delete(f"/api/v1/restaurants/{restaurant.slug}/")
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "forbidden"
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        restaurant.owner.delete()
+        regular_user.delete()
+
+
+def test_restaurant_delete_success_by_admin():
+    """DELETE /restaurants/{slug}/ succeeds for admin user."""
+    client = Client()
+    admin = _create_user(role=UserRole.ADMIN)
+    restaurant = _create_restaurant()
+
+    try:
+        client.force_login(admin)
+        response = client.delete(f"/api/v1/restaurants/{restaurant.slug}/")
+
+        assert response.status_code == 204
+        assert not Restaurant.objects.filter(slug=restaurant.slug).exists()
+    finally:
+        admin.delete()
+
+
+def test_restaurant_delete_not_found():
+    """DELETE /restaurants/{slug}/ returns 404 for non-existent slug."""
+    client = Client()
+    admin = _create_user(role=UserRole.ADMIN)
+    client.force_login(admin)
+
+    response = client.delete("/api/v1/restaurants/nonexistent-slug/")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+    admin.delete()
+
+
+def test_restaurant_delete_owner_cannot_delete():
+    """DELETE /restaurants/{slug}/ fails for owner role."""
+    client = Client()
+    owner = _create_user(role=UserRole.OWNER)
+    restaurant = _create_restaurant()
+
+    try:
+        client.force_login(owner)
+        response = client.delete(f"/api/v1/restaurants/{restaurant.slug}/")
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "forbidden"
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        owner.delete()

--- a/apps/api/restaurants/views.py
+++ b/apps/api/restaurants/views.py
@@ -1,8 +1,19 @@
 """Views for restaurant endpoints."""
 
-from api_http import Controller, controller, delete, get, patch, post
+from api_http import (
+    Controller,
+    UserIsAuthenticated,
+    UserRoleRequired,
+    controller,
+    delete,
+    get,
+    guard,
+    patch,
+    post,
+)
 from restaurants.dtos import RestaurantDto
 from restaurants.models import Restaurant
+from users.models import UserRole
 
 
 @controller()
@@ -107,6 +118,8 @@ class RestaurantsController(Controller):
         )
 
     @delete("<slug:slug>/")
+    @guard(UserIsAuthenticated)
+    @guard(UserRoleRequired(UserRole.ADMIN))
     def restaurant_delete(self, slug):
         """Scaffold for admin-only restaurant deletion."""
         # TODO(implementation guide):
@@ -118,10 +131,13 @@ class RestaurantsController(Controller):
         # 4) Delete model and return api_http no-content helper:
         #    - restaurant.delete()
         #    - return self.no_content()
-        return self.error(
-            status=501,
-            code="not_implemented",
-            message=(
-                f"restaurant_delete for slug '{slug}' is scaffolded but not implemented."
-            ),
-        )
+        restaurant = Restaurant.objects.filter(slug=slug).first()
+        if restaurant is None:
+            return self.error(
+                status=404,
+                code="not_found",
+                message="Restaurant not found.",
+            )
+
+        restaurant.delete()
+        return self.no_content()

--- a/apps/api/restaurants/views.py
+++ b/apps/api/restaurants/views.py
@@ -66,18 +66,13 @@ class RestaurantsController(Controller):
         return self.json({"data": data})
 
     @post()
+    @guard(UserIsAuthenticated)
+    @guard(UserRoleRequired(UserRole.OWNER))
     def restaurant_create(self):
         """Scaffold for owner-only restaurant creation."""
         # TODO(implementation guide):
-        # 1) Auth check with request user + api_http error helper.
-        #    - user = getattr(self.request, "user", None)
-        #    - if user is None or not user.is_authenticated:
-        #        return self.error(status=401, code="auth_required", message="Authentication is required.")
-        #
-        # 2) Role check for owners.
-        #    - from users.models import UserRole
-        #    - if user.role != UserRole.OWNER:
-        #        return self.error(status=403, code="forbidden", message="Only restaurant owners can create restaurants.")
+        # 1) Auth check (skip)
+        # 2) Role check for owners (skip)
         #
         # 3) Parse request JSON body and validate required fields.
         #    - validate at least: name, description, category_id, address_line1, city
@@ -96,10 +91,12 @@ class RestaurantsController(Controller):
         )
 
     @patch("<slug:slug>/")
+    @guard(UserIsAuthenticated)
+    @guard(UserRoleRequired(UserRole.OWNER))
     def restaurant_update(self, slug):
         """Scaffold for owner-only restaurant update."""
-        # TODO(implementation guide):
-        # 1) Repeat auth + owner role checks (same api_http `self.error(...)` pattern as create).
+        # TODO: (implementation guide)
+        # 1)  auth check (skip)
         # 2) Load restaurant by slug:
         #    - restaurant = Restaurant.objects.filter(slug=slug).first()
         #    - if restaurant is None: return self.error(status=404, code="not_found", message="Restaurant not found.")
@@ -121,15 +118,6 @@ class RestaurantsController(Controller):
     @guard(UserRoleRequired(UserRole.ADMIN))
     def restaurant_delete(self, slug):
         """Scaffold for admin-only restaurant deletion."""
-        # TODO(implementation guide):
-        # 1) Require authenticated user with the same auth check pattern.
-        # 2) Admin role check.
-        #    - from users.models import UserRole
-        #    - if user.role != UserRole.ADMIN: return self.error(status=403, code="forbidden", ...)
-        # 3) Load by slug and return 404 if not found.
-        # 4) Delete model and return api_http no-content helper:
-        #    - restaurant.delete()
-        #    - return self.no_content()
         restaurant = Restaurant.objects.filter(slug=slug).first()
         if restaurant is None:
             return self.error(

--- a/libs/api-http/api_http/__init__.py
+++ b/libs/api-http/api_http/__init__.py
@@ -1,5 +1,5 @@
 """Public API for the internal api_http library."""
-
+from .guards import UserIsAuthenticated, UserRoleRequired, guard
 from .errors import (
     ApiHttpError,
     ConflictError,
@@ -58,4 +58,7 @@ __all__ = [
     "post",
     "put",
     "use",
+    "guard",
+    "UserIsAuthenticated",
+    "UserRoleRequired",
 ]

--- a/libs/api-http/api_http/guards.py
+++ b/libs/api-http/api_http/guards.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from django.http import HttpResponse
 
 from .decorators import use
+from .responses import ErrorResponse
 
 
 class UserIsAuthenticated:
@@ -15,16 +16,16 @@ class UserIsAuthenticated:
         self, func: Callable[..., HttpResponse]
     ) -> Callable[..., HttpResponse]:
         @wraps(func)
-        def wrapper(self: Any, *args: Any, **kwargs: Any) -> HttpResponse:
-            user = getattr(self.request, "user", None)
+        def wrapper(request: Any, *args: Any, **kwargs: Any) -> HttpResponse:
+            user = getattr(request, "user", None)
             if user is None or not user.is_authenticated:
-                return self.error(
+                return ErrorResponse(
                     status=401,
-                    code="auth_required",
+                    error_code="auth_required",
                     message="Authentication is required.",
                 )
 
-            return func(self, *args, **kwargs)
+            return func(request, *args, **kwargs)
 
         return wrapper
 
@@ -39,23 +40,23 @@ class UserRoleRequired:
         self, func: Callable[..., HttpResponse]
     ) -> Callable[..., HttpResponse]:
         @wraps(func)
-        def wrapper(self: Any, *args: Any, **kwargs: Any) -> HttpResponse:
-            user = getattr(self.request, "user", None)
+        def wrapper(request: Any, *args: Any, **kwargs: Any) -> HttpResponse:
+            user = getattr(request, "user", None)
             if user is None or not user.is_authenticated:
-                return self.error(
+                return ErrorResponse(
                     status=401,
-                    code="auth_required",
+                    error_code="auth_required",
                     message="Authentication is required.",
                 )
 
             if user.role != self.role:
-                return self.error(
+                return ErrorResponse(
                     status=403,
-                    code="forbidden",
+                    error_code="forbidden",
                     message="You do not have permission to perform this action.",
                 )
 
-            return func(self, *args, **kwargs)
+            return func(request, *args, **kwargs)
 
         return wrapper
 

--- a/libs/api-http/api_http/guards.py
+++ b/libs/api-http/api_http/guards.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from django.http import HttpResponse
+
+from .decorators import use
+
+
+class UserIsAuthenticated:
+    """Guard requiring an authenticated request user."""
+
+    def __call__(
+        self, func: Callable[..., HttpResponse]
+    ) -> Callable[..., HttpResponse]:
+        @wraps(func)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> HttpResponse:
+            user = getattr(self.request, "user", None)
+            if user is None or not user.is_authenticated:
+                return self.error(
+                    status=401,
+                    code="auth_required",
+                    message="Authentication is required.",
+                )
+
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+
+class UserRoleRequired:
+    """Guard requiring the authenticated user to have a specific role."""
+
+    def __init__(self, role: Any) -> None:
+        self.role = role
+
+    def __call__(
+        self, func: Callable[..., HttpResponse]
+    ) -> Callable[..., HttpResponse]:
+        @wraps(func)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> HttpResponse:
+            user = getattr(self.request, "user", None)
+            if user is None or not user.is_authenticated:
+                return self.error(
+                    status=401,
+                    code="auth_required",
+                    message="Authentication is required.",
+                )
+
+            if user.role != self.role:
+                return self.error(
+                    status=403,
+                    code="forbidden",
+                    message="You do not have permission to perform this action.",
+                )
+
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+
+def guard(guard_definition: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Attach a guard to a route handler through the existing use(...) system."""
+
+    guard_instance = (
+        guard_definition() if isinstance(guard_definition, type) else guard_definition
+    )
+    return use(guard_instance)

--- a/libs/api-http/tests/conftest.py
+++ b/libs/api-http/tests/conftest.py
@@ -12,7 +12,16 @@ def pytest_configure() -> None:
             ALLOWED_HOSTS=["*"],
             ROOT_URLCONF=__name__,
             MIDDLEWARE=[],
-            INSTALLED_APPS=[],
+            INSTALLED_APPS=[
+                "django.contrib.contenttypes",
+                "django.contrib.auth",
+            ],
             DEFAULT_CHARSET="utf-8",
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": ":memory:",
+                }
+            },
         )
     django.setup()

--- a/libs/api-http/tests/test_guards.py
+++ b/libs/api-http/tests/test_guards.py
@@ -1,0 +1,179 @@
+"""Tests for guards: UserIsAuthenticated and UserRoleRequired."""
+
+import json
+
+import pytest
+from django.test import RequestFactory
+
+from api_http import (
+    Controller,
+    UserIsAuthenticated,
+    UserRoleRequired,
+    build_urlpatterns,
+    controller,
+    delete,
+    get,
+    guard,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+class MockUser:
+    def __init__(self, is_authenticated=True, role=None):
+        self.is_authenticated = is_authenticated
+        self.role = role
+
+
+def test_guard_UserIsAuthenticated_rejects_unauthenticated():
+    @controller()
+    class ProtectedController(Controller):
+        @guard(UserIsAuthenticated)
+        @get()
+        def protected(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(ProtectedController)[0].callback
+    request = RequestFactory().get("/protected/")
+    request.user = MockUser(is_authenticated=False)
+
+    response = view(request)
+
+    assert response.status_code == 401
+    import json
+
+    assert json.loads(response.content)["error"]["code"] == "auth_required"
+
+
+def test_guard_UserIsAuthenticated_rejects_missing_user():
+    @controller()
+    class ProtectedController(Controller):
+        @guard(UserIsAuthenticated)
+        @get()
+        def protected(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(ProtectedController)[0].callback
+    request = RequestFactory().get("/protected/")
+    request.user = None
+
+    response = view(request)
+
+    assert response.status_code == 401
+
+    assert json.loads(response.content)["error"]["code"] == "auth_required"
+
+
+def test_guard_UserIsAuthenticated_allows_authenticated():
+    @controller()
+    class ProtectedController(Controller):
+        @guard(UserIsAuthenticated)
+        @get()
+        def protected(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(ProtectedController)[0].callback
+    request = RequestFactory().get("/protected/")
+    request.user = MockUser(is_authenticated=True)
+
+    response = view(request)
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["status"] == "ok"
+
+
+def test_guard_UserRoleRequired_rejects_wrong_role():
+    @controller()
+    class AdminController(Controller):
+        @guard(UserRoleRequired("admin"))
+        @get()
+        def admin_only(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(AdminController)[0].callback
+    request = RequestFactory().get("/admin-only/")
+    request.user = MockUser(is_authenticated=True, role="user")
+
+    response = view(request)
+
+    assert response.status_code == 403
+    assert json.loads(response.content)["error"]["code"] == "forbidden"
+
+
+def test_guard_UserRoleRequired_rejects_unauthenticated():
+    @controller()
+    class AdminController(Controller):
+        @guard(UserRoleRequired("admin"))
+        @get()
+        def admin_only(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(AdminController)[0].callback
+    request = RequestFactory().get("/admin-only/")
+    request.user = MockUser(is_authenticated=False, role="user")
+
+    response = view(request)
+
+    assert response.status_code == 401
+    assert json.loads(response.content)["error"]["code"] == "auth_required"
+
+
+def test_guard_UserRoleRequired_allows_correct_role():
+    @controller()
+    class AdminController(Controller):
+        @guard(UserRoleRequired("admin"))
+        @get()
+        def admin_only(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(AdminController)[0].callback
+    request = RequestFactory().get("/admin-only/")
+    request.user = MockUser(is_authenticated=True, role="admin")
+
+    response = view(request)
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["status"] == "ok"
+
+
+def test_guard_UserRoleRequired_with_enum():
+    @controller()
+    class OwnerController(Controller):
+        @guard(UserRoleRequired("owner"))
+        @get()
+        def owner_only(self):
+            return self.ok({"status": "ok"})
+
+    view = build_urlpatterns(OwnerController)[0].callback
+
+    request = RequestFactory().get("/owner-only/")
+    request.user = MockUser(is_authenticated=True, role="user")
+    response = view(request)
+    assert response.status_code == 403
+
+    request = RequestFactory().get("/owner-only/")
+    request.user = MockUser(is_authenticated=True, role="owner")
+    response = view(request)
+    assert response.status_code == 200
+
+
+def test_guard_chaining_multiple_guards():
+    @controller()
+    class ChainedController(Controller):
+        @guard(UserIsAuthenticated)
+        @guard(UserRoleRequired("admin"))
+        @delete()
+        def delete_resource(self):
+            return self.no_content()
+
+    view = build_urlpatterns(ChainedController)[0].callback
+
+    request = RequestFactory().delete("/delete/")
+    request.user = MockUser(is_authenticated=True, role="user")
+    response = view(request)
+    assert response.status_code == 403
+
+    request = RequestFactory().delete("/delete/")
+    request.user = MockUser(is_authenticated=True, role="admin")
+    response = view(request)
+    assert response.status_code == 204


### PR DESCRIPTION
Implemented guard-based endpoint security checks in `api_http`.

Added:
- `guard(...)`
- `UserIsAuthenticated`
- `UserRoleRequired(role)`

Applied as a proof of concept to `restaurant_delete` so repeated authentication and role checks are encapsulated and the endpoint keeps only business logic.