### PR TITLE
feat(api): add menu item CRUD endpoints

### DIFF
--- a/apps/api/restaurants/admin.py
+++ b/apps/api/restaurants/admin.py
@@ -41,8 +41,8 @@ class RestaurantAdmin(admin.ModelAdmin):
 class MenuItemAdmin(admin.ModelAdmin):
     """Admin settings for menu items."""
 
-    list_display = ("name", "restaurant", "price", "currency", "is_available")
-    list_filter = ("currency", "is_available")
+    list_display = ("name", "restaurant", "category", "price", "currency", "is_available")
+    list_filter = ("category", "currency", "is_available")
     search_fields = ("name", "restaurant__name")
     ordering = ("restaurant", "sort_order", "name")
 

--- a/apps/api/restaurants/migrations/0004_menuitem_category.py
+++ b/apps/api/restaurants/migrations/0004_menuitem_category.py
@@ -1,0 +1,18 @@
+# Generated manually for issue #4.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("restaurants", "0003_remove_category_icon_url_category_icon_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="menuitem",
+            name="category",
+            field=models.CharField(blank=True, default="", max_length=100),
+        ),
+    ]

--- a/apps/api/restaurants/migrations/0004_menuitem_category.py
+++ b/apps/api/restaurants/migrations/0004_menuitem_category.py
@@ -1,6 +1,14 @@
 # Generated manually for issue #4.
 
+import django.db.models.deletion
 from django.db import migrations, models
+
+
+def copy_restaurant_category_to_menu_items(apps, schema_editor):
+    MenuItem = apps.get_model("restaurants", "MenuItem")
+    for menu_item in MenuItem.objects.filter(category__isnull=True).select_related("restaurant"):
+        menu_item.category_id = menu_item.restaurant.category_id
+        menu_item.save(update_fields=["category"])
 
 
 class Migration(migrations.Migration):
@@ -13,6 +21,24 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="menuitem",
             name="category",
-            field=models.CharField(blank=True, default="", max_length=100),
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="menu_items",
+                to="restaurants.category",
+            ),
+        ),
+        migrations.RunPython(
+            copy_restaurant_category_to_menu_items,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="menuitem",
+            name="category",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="menu_items",
+                to="restaurants.category",
+            ),
         ),
     ]

--- a/apps/api/restaurants/models.py
+++ b/apps/api/restaurants/models.py
@@ -145,6 +145,7 @@ class MenuItem(models.Model):
     )
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True)
+    category = models.CharField(max_length=100, blank=True, default="")
     price = models.DecimalField(max_digits=10, decimal_places=2)
     currency = models.CharField(max_length=3, default="EUR")
     image = models.ForeignKey(

--- a/apps/api/restaurants/models.py
+++ b/apps/api/restaurants/models.py
@@ -145,7 +145,11 @@ class MenuItem(models.Model):
     )
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True)
-    category = models.CharField(max_length=100, blank=True, default="")
+    category = models.ForeignKey(
+        Category,
+        on_delete=models.PROTECT,
+        related_name="menu_items",
+    )
     price = models.DecimalField(max_digits=10, decimal_places=2)
     currency = models.CharField(max_length=3, default="EUR")
     image = models.ForeignKey(

--- a/apps/api/restaurants/repositories.py
+++ b/apps/api/restaurants/repositories.py
@@ -31,12 +31,12 @@ class RestaurantRepository:
         restaurant.delete()
 
     def list_menu_items(self, restaurant):
-        return MenuItem.objects.filter(restaurant=restaurant).select_related("restaurant", "image")
+        return MenuItem.objects.filter(restaurant=restaurant).select_related("restaurant", "category", "image")
 
     def get_menu_item(self, *, restaurant, menu_item_id):
         return (
             MenuItem.objects.filter(id=menu_item_id, restaurant=restaurant)
-            .select_related("restaurant", "image")
+            .select_related("restaurant", "category", "image")
             .first()
         )
 

--- a/apps/api/restaurants/repositories.py
+++ b/apps/api/restaurants/repositories.py
@@ -1,6 +1,6 @@
 """Restaurant data access layer."""
 
-from restaurants.models import Category, Restaurant
+from restaurants.models import Category, MenuItem, Restaurant
 
 
 class RestaurantRepository:
@@ -29,3 +29,25 @@ class RestaurantRepository:
 
     def delete(self, restaurant: Restaurant) -> None:
         restaurant.delete()
+
+    def list_menu_items(self, restaurant):
+        return MenuItem.objects.filter(restaurant=restaurant).select_related("restaurant", "image")
+
+    def get_menu_item(self, *, restaurant, menu_item_id):
+        return (
+            MenuItem.objects.filter(id=menu_item_id, restaurant=restaurant)
+            .select_related("restaurant", "image")
+            .first()
+        )
+
+    def create_menu_item(self, *, restaurant, data: dict) -> MenuItem:
+        return MenuItem.objects.create(restaurant=restaurant, **data)
+
+    def save_menu_item(self, menu_item: MenuItem, data: dict) -> MenuItem:
+        for field, value in data.items():
+            setattr(menu_item, field, value)
+        menu_item.save()
+        return menu_item
+
+    def delete_menu_item(self, menu_item: MenuItem) -> None:
+        menu_item.delete()

--- a/apps/api/restaurants/serializers.py
+++ b/apps/api/restaurants/serializers.py
@@ -3,13 +3,13 @@
 from rest_framework import serializers
 
 from api.serializers import DynamicFieldsModelSerializer
-from restaurants.models import Category, Restaurant
 from files.services import create_file_service
+from restaurants.models import Category, MenuItem, Restaurant
 
 
 class CategorySerializer(serializers.ModelSerializer):
     """Nested category serializer."""
-    
+
     icon_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -20,6 +20,59 @@ class CategorySerializer(serializers.ModelSerializer):
         if not obj.icon_id:
             return None
         return create_file_service().get_obfuscated_url(obj.icon_id)
+
+
+class MenuItemSerializer(serializers.ModelSerializer):
+    """Restaurant menu item read serializer."""
+
+    restaurant_id = serializers.UUIDField(read_only=True)
+    image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MenuItem
+        fields = [
+            "id",
+            "restaurant_id",
+            "name",
+            "description",
+            "category",
+            "price",
+            "currency",
+            "image",
+            "image_url",
+            "is_available",
+            "sort_order",
+        ]
+
+    def get_image_url(self, obj) -> str | None:
+        if not obj.image_id:
+            return None
+        return create_file_service().get_obfuscated_url(obj.image_id)
+
+
+class MenuItemWriteSerializer(serializers.ModelSerializer):
+    """Request serializer for menu item create/update."""
+
+    class Meta:
+        model = MenuItem
+        fields = [
+            "name",
+            "description",
+            "category",
+            "price",
+            "currency",
+            "image",
+            "is_available",
+            "sort_order",
+        ]
+        extra_kwargs = {
+            "description": {"required": False},
+            "category": {"required": False},
+            "currency": {"required": False},
+            "image": {"required": False},
+            "is_available": {"required": False},
+            "sort_order": {"required": False},
+        }
 
 
 class RestaurantSerializer(DynamicFieldsModelSerializer):

--- a/apps/api/restaurants/serializers.py
+++ b/apps/api/restaurants/serializers.py
@@ -26,6 +26,7 @@ class MenuItemSerializer(serializers.ModelSerializer):
     """Restaurant menu item read serializer."""
 
     restaurant_id = serializers.UUIDField(read_only=True)
+    category = CategorySerializer(read_only=True)
     image_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -53,12 +54,20 @@ class MenuItemSerializer(serializers.ModelSerializer):
 class MenuItemWriteSerializer(serializers.ModelSerializer):
     """Request serializer for menu item create/update."""
 
+    category_id = serializers.PrimaryKeyRelatedField(
+        queryset=Category.objects.all(),
+        source="category",
+        required=True,
+    )
+    currency = serializers.CharField(max_length=3, required=True)
+    is_available = serializers.BooleanField(required=True)
+
     class Meta:
         model = MenuItem
         fields = [
             "name",
             "description",
-            "category",
+            "category_id",
             "price",
             "currency",
             "image",
@@ -67,13 +76,9 @@ class MenuItemWriteSerializer(serializers.ModelSerializer):
         ]
         extra_kwargs = {
             "description": {"required": False},
-            "category": {"required": False},
-            "currency": {"required": False},
             "image": {"required": False},
-            "is_available": {"required": False},
             "sort_order": {"required": False},
         }
-
 
 class RestaurantSerializer(DynamicFieldsModelSerializer):
     """Restaurant read serializer."""

--- a/apps/api/restaurants/services.py
+++ b/apps/api/restaurants/services.py
@@ -60,3 +60,38 @@ class RestaurantService:
                 detail="You do not have permission to delete this restaurant.",
             )
         self.repository.delete(restaurant)
+
+    def list_menu_items(self, restaurant):
+        return self.repository.list_menu_items(restaurant)
+
+    def get_menu_item(self, *, restaurant, menu_item_id):
+        menu_item = self.repository.get_menu_item(
+            restaurant=restaurant,
+            menu_item_id=menu_item_id,
+        )
+        if menu_item is None:
+            raise ApiError(status_code=404, code="not_found", detail="Menu item not found.")
+        return menu_item
+
+    def create_menu_item(self, *, user, restaurant, data: dict):
+        self._require_menu_manager(user=user, restaurant=restaurant)
+        return self.repository.create_menu_item(restaurant=restaurant, data=data)
+
+    def update_menu_item(self, *, user, restaurant, menu_item, data: dict):
+        self._require_menu_manager(user=user, restaurant=restaurant)
+        return self.repository.save_menu_item(menu_item, data)
+
+    def delete_menu_item(self, *, user, restaurant, menu_item) -> None:
+        self._require_menu_manager(user=user, restaurant=restaurant)
+        self.repository.delete_menu_item(menu_item)
+
+    def _require_menu_manager(self, *, user, restaurant) -> None:
+        if user.role == UserRole.ADMIN:
+            return
+        if user.role == UserRole.OWNER and restaurant.owner_id == user.id:
+            return
+        raise ApiError(
+            status_code=403,
+            code="forbidden",
+            detail="You do not have permission to manage this restaurant menu.",
+        )

--- a/apps/api/restaurants/tests.py
+++ b/apps/api/restaurants/tests.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 
-from restaurants.models import Category, Restaurant
+from restaurants.models import Category, MenuItem, Restaurant
 from users.models import UserRole
 
 pytestmark = pytest.mark.django_db
@@ -238,3 +238,153 @@ def test_restaurant_delete_owner_cannot_delete():
         restaurant.delete()
         restaurant.category.delete()
         owner.delete()
+
+
+def test_menu_item_list_no_auth_required():
+    """GET /restaurants/{slug}/menu-items/ exposes menu items for a restaurant."""
+    client = Client()
+    restaurant = _create_restaurant()
+    menu_item = MenuItem.objects.create(
+        restaurant=restaurant,
+        name="Test Burger",
+        description="A test menu item",
+        category="Main",
+        price="12.50",
+    )
+
+    try:
+        response = client.get(f"/api/v1/restaurants/{restaurant.slug}/menu-items/")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["data"][0]["id"] == str(menu_item.id)
+        assert payload["data"][0]["name"] == "Test Burger"
+        assert payload["data"][0]["category"] == "Main"
+        assert payload["data"][0]["price"] == "12.50"
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        restaurant.owner.delete()
+
+
+def test_menu_item_create_requires_authentication():
+    """POST /restaurants/{slug}/menu-items/ requires a logged-in user."""
+    client = Client()
+    restaurant = _create_restaurant()
+
+    try:
+        response = client.post(
+            f"/api/v1/restaurants/{restaurant.slug}/menu-items/",
+            data={"name": "Soup", "price": "7.00"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "auth_required"
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        restaurant.owner.delete()
+
+
+def test_menu_item_create_update_delete_by_restaurant_owner():
+    """Restaurant owners can create, update, and delete their own menu items."""
+    client = Client()
+    owner = _create_user(role=UserRole.OWNER)
+    restaurant = _create_restaurant(owner=owner)
+
+    try:
+        client.force_login(owner)
+        create_response = client.post(
+            f"/api/v1/restaurants/{restaurant.slug}/menu-items/",
+            data={
+                "name": "Lentil Soup",
+                "description": "Warm starter",
+                "category": "Starter",
+                "price": "6.50",
+            },
+            content_type="application/json",
+        )
+
+        assert create_response.status_code == 201
+        created = create_response.json()["data"]
+        assert created["name"] == "Lentil Soup"
+        assert created["category"] == "Starter"
+
+        menu_item_id = created["id"]
+        patch_response = client.patch(
+            f"/api/v1/restaurants/{restaurant.slug}/menu-items/{menu_item_id}/",
+            data={"price": "7.25", "is_available": False},
+            content_type="application/json",
+        )
+
+        assert patch_response.status_code == 200
+        patched = patch_response.json()["data"]
+        assert patched["price"] == "7.25"
+        assert patched["is_available"] is False
+
+        delete_response = client.delete(
+            f"/api/v1/restaurants/{restaurant.slug}/menu-items/{menu_item_id}/"
+        )
+
+        assert delete_response.status_code == 204
+        assert not MenuItem.objects.filter(id=menu_item_id).exists()
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        owner.delete()
+
+
+def test_menu_item_create_for_other_owner_forbidden():
+    """Owners cannot manage another owner's restaurant menu."""
+    client = Client()
+    owner = _create_user(role=UserRole.OWNER)
+    other_owner = _create_user(role=UserRole.OWNER)
+    restaurant = _create_restaurant(owner=owner)
+
+    try:
+        client.force_login(other_owner)
+        response = client.post(
+            f"/api/v1/restaurants/{restaurant.slug}/menu-items/",
+            data={"name": "Soup", "price": "7.00"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "forbidden"
+    finally:
+        restaurant.delete()
+        restaurant.category.delete()
+        owner.delete()
+        other_owner.delete()
+
+
+def test_menu_item_detail_is_scoped_to_restaurant():
+    """Menu item detail routes should not leak items from a different restaurant."""
+    client = Client()
+    first_restaurant = _create_restaurant()
+    second_restaurant = _create_restaurant()
+    menu_item = MenuItem.objects.create(
+        restaurant=first_restaurant,
+        name="Only First Restaurant",
+        price="10.00",
+    )
+
+    try:
+        response = client.get(
+            f"/api/v1/restaurants/{second_restaurant.slug}/menu-items/{menu_item.id}/"
+        )
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "not_found"
+    finally:
+        first_owner = first_restaurant.owner
+        second_owner = second_restaurant.owner
+        first_category = first_restaurant.category
+        second_category = second_restaurant.category
+        first_restaurant.delete()
+        second_restaurant.delete()
+        first_category.delete()
+        second_category.delete()
+        first_owner.delete()
+        second_owner.delete()

--- a/apps/api/restaurants/tests.py
+++ b/apps/api/restaurants/tests.py
@@ -248,8 +248,10 @@ def test_menu_item_list_no_auth_required():
         restaurant=restaurant,
         name="Test Burger",
         description="A test menu item",
-        category="Main",
+        category=restaurant.category,
         price="12.50",
+        currency="EUR",
+        is_available=True,
     )
 
     try:
@@ -259,7 +261,7 @@ def test_menu_item_list_no_auth_required():
         payload = response.json()
         assert payload["data"][0]["id"] == str(menu_item.id)
         assert payload["data"][0]["name"] == "Test Burger"
-        assert payload["data"][0]["category"] == "Main"
+        assert payload["data"][0]["category"]["id"] == str(restaurant.category_id)
         assert payload["data"][0]["price"] == "12.50"
     finally:
         restaurant.delete()
@@ -275,7 +277,13 @@ def test_menu_item_create_requires_authentication():
     try:
         response = client.post(
             f"/api/v1/restaurants/{restaurant.slug}/menu-items/",
-            data={"name": "Soup", "price": "7.00"},
+            data={
+                "name": "Soup",
+                "category_id": str(restaurant.category_id),
+                "price": "7.00",
+                "currency": "EUR",
+                "is_available": True,
+            },
             content_type="application/json",
         )
 
@@ -300,8 +308,10 @@ def test_menu_item_create_update_delete_by_restaurant_owner():
             data={
                 "name": "Lentil Soup",
                 "description": "Warm starter",
-                "category": "Starter",
+                "category_id": str(restaurant.category_id),
                 "price": "6.50",
+                "currency": "EUR",
+                "is_available": True,
             },
             content_type="application/json",
         )
@@ -309,7 +319,7 @@ def test_menu_item_create_update_delete_by_restaurant_owner():
         assert create_response.status_code == 201
         created = create_response.json()["data"]
         assert created["name"] == "Lentil Soup"
-        assert created["category"] == "Starter"
+        assert created["category"]["id"] == str(restaurant.category_id)
 
         menu_item_id = created["id"]
         patch_response = client.patch(
@@ -346,7 +356,13 @@ def test_menu_item_create_for_other_owner_forbidden():
         client.force_login(other_owner)
         response = client.post(
             f"/api/v1/restaurants/{restaurant.slug}/menu-items/",
-            data={"name": "Soup", "price": "7.00"},
+            data={
+                "name": "Soup",
+                "category_id": str(restaurant.category_id),
+                "price": "7.00",
+                "currency": "EUR",
+                "is_available": True,
+            },
             content_type="application/json",
         )
 
@@ -367,7 +383,10 @@ def test_menu_item_detail_is_scoped_to_restaurant():
     menu_item = MenuItem.objects.create(
         restaurant=first_restaurant,
         name="Only First Restaurant",
+        category=first_restaurant.category,
         price="10.00",
+        currency="EUR",
+        is_available=True,
     )
 
     try:

--- a/apps/api/restaurants/urls.py
+++ b/apps/api/restaurants/urls.py
@@ -1,11 +1,27 @@
 from django.urls import path
 
 from reviews.views import RestaurantReviewsController
-from restaurants.views import RestaurantDetailController, OwnerRestaurantsController, RestaurantsController
+from restaurants.views import (
+    OwnerRestaurantsController,
+    RestaurantDetailController,
+    RestaurantMenuItemDetailController,
+    RestaurantMenuItemsController,
+    RestaurantsController,
+)
 
 urlpatterns = [
     path("", RestaurantsController.as_view(), name="restaurants-list"),
     path("mine/", OwnerRestaurantsController.as_view(), name="restaurants-mine"),
+    path(
+        "<slug:restaurant_slug>/menu-items/",
+        RestaurantMenuItemsController.as_view(),
+        name="restaurants-menu-items",
+    ),
+    path(
+        "<slug:restaurant_slug>/menu-items/<uuid:menu_item_id>/",
+        RestaurantMenuItemDetailController.as_view(),
+        name="restaurants-menu-items-detail",
+    ),
     path(
         "<slug:restaurant_slug>/reviews/",
         RestaurantReviewsController.as_view(),

--- a/apps/api/restaurants/views.py
+++ b/apps/api/restaurants/views.py
@@ -1,6 +1,6 @@
 """Views for restaurant endpoints."""
 
-from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -13,6 +13,8 @@ from api.rest import (
 )
 from restaurants.serializers import (
     CategorySerializer,
+    MenuItemSerializer,
+    MenuItemWriteSerializer,
     RestaurantSerializer,
     RestaurantUpdateSerializer,
     RestaurantWriteSerializer,
@@ -127,6 +129,112 @@ class OwnerRestaurantsController(APIView):
         user = require_authenticated_user(request)
         restaurants = self.get_service().list_owned_restaurants(user)
         return api_data(RestaurantSerializer(restaurants, many=True).data)
+
+
+class RestaurantMenuItemsController(APIView):
+    """List or create menu items for a restaurant."""
+
+    service_class = RestaurantService
+
+    def get_service(self) -> RestaurantService:
+        return self.service_class()
+
+    @extend_schema(
+        summary="List restaurant menu items",
+        responses={200: MenuItemSerializer(many=True)},
+        tags=["Menu Items"],
+    )
+    def get(self, request, restaurant_slug):
+        service = self.get_service()
+        restaurant = service.get_restaurant(restaurant_slug)
+        menu_items = service.list_menu_items(restaurant)
+        return api_data(MenuItemSerializer(menu_items, many=True).data)
+
+    @extend_schema(
+        summary="Create restaurant menu item",
+        request=MenuItemWriteSerializer,
+        responses={201: MenuItemSerializer},
+        tags=["Menu Items"],
+    )
+    def post(self, request, restaurant_slug):
+        service = self.get_service()
+        restaurant = service.get_restaurant(restaurant_slug)
+        user = require_authenticated_user(request)
+        serializer = MenuItemWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        menu_item = service.create_menu_item(
+            user=user,
+            restaurant=restaurant,
+            data=serializer.validated_data,
+        )
+        return api_data(MenuItemSerializer(menu_item).data, status_code=201)
+
+
+class RestaurantMenuItemDetailController(APIView):
+    """Retrieve, update, or delete one restaurant menu item."""
+
+    service_class = RestaurantService
+
+    def get_service(self) -> RestaurantService:
+        return self.service_class()
+
+    @extend_schema(
+        summary="Get restaurant menu item",
+        responses={200: MenuItemSerializer},
+        tags=["Menu Items"],
+    )
+    def get(self, request, restaurant_slug, menu_item_id):
+        service = self.get_service()
+        restaurant = service.get_restaurant(restaurant_slug)
+        menu_item = service.get_menu_item(
+            restaurant=restaurant,
+            menu_item_id=menu_item_id,
+        )
+        return api_data(MenuItemSerializer(menu_item).data)
+
+    @extend_schema(
+        summary="Update restaurant menu item",
+        request=MenuItemWriteSerializer,
+        responses={200: MenuItemSerializer},
+        tags=["Menu Items"],
+    )
+    def patch(self, request, restaurant_slug, menu_item_id):
+        service = self.get_service()
+        restaurant = service.get_restaurant(restaurant_slug)
+        menu_item = service.get_menu_item(
+            restaurant=restaurant,
+            menu_item_id=menu_item_id,
+        )
+        user = require_authenticated_user(request)
+        serializer = MenuItemWriteSerializer(menu_item, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        menu_item = service.update_menu_item(
+            user=user,
+            restaurant=restaurant,
+            menu_item=menu_item,
+            data=serializer.validated_data,
+        )
+        return api_data(MenuItemSerializer(menu_item).data)
+
+    @extend_schema(
+        summary="Delete restaurant menu item",
+        responses={204: None},
+        tags=["Menu Items"],
+    )
+    def delete(self, request, restaurant_slug, menu_item_id):
+        service = self.get_service()
+        restaurant = service.get_restaurant(restaurant_slug)
+        menu_item = service.get_menu_item(
+            restaurant=restaurant,
+            menu_item_id=menu_item_id,
+        )
+        user = require_authenticated_user(request)
+        service.delete_menu_item(
+            user=user,
+            restaurant=restaurant,
+            menu_item=menu_item,
+        )
+        return Response(status=204)
 
 
 class RestaurantDetailController(APIView):

--- a/apps/api/tests/test_drf_architecture.py
+++ b/apps/api/tests/test_drf_architecture.py
@@ -26,6 +26,8 @@ def test_urls_are_backed_by_drf_controller_classes():
     assert _view_class(user_urlpatterns, "me/").__name__ == "UsersController"
     assert _view_class(restaurant_urlpatterns, "").__name__ == "RestaurantsController"
     assert _view_class(restaurant_urlpatterns, "<slug:slug>/").__name__ == "RestaurantDetailController"
+    assert _view_class(restaurant_urlpatterns, "<slug:restaurant_slug>/menu-items/").__name__ == "RestaurantMenuItemsController"
+    assert _view_class(restaurant_urlpatterns, "<slug:restaurant_slug>/menu-items/<uuid:menu_item_id>/").__name__ == "RestaurantMenuItemDetailController"
     assert _view_class(review_urlpatterns, "restaurants/<slug:restaurant_slug>/").__name__ == "RestaurantReviewsController"
     assert _view_class(review_urlpatterns, "<uuid:review_id>/").__name__ == "ReviewController"
     assert _view_class(review_urlpatterns, "<uuid:review_id>/like/").__name__ == "ReviewLikeController"
@@ -43,6 +45,8 @@ def test_controllers_depend_on_services():
     assert _view_class(user_urlpatterns, "me/").service_class is UserService
     assert _view_class(restaurant_urlpatterns, "").service_class is RestaurantService
     assert _view_class(restaurant_urlpatterns, "<slug:slug>/").service_class is RestaurantService
+    assert _view_class(restaurant_urlpatterns, "<slug:restaurant_slug>/menu-items/").service_class is RestaurantService
+    assert _view_class(restaurant_urlpatterns, "<slug:restaurant_slug>/menu-items/<uuid:menu_item_id>/").service_class is RestaurantService
     assert _view_class(review_urlpatterns, "restaurants/<slug:restaurant_slug>/").service_class is ReviewService
     assert _view_class(review_urlpatterns, "<uuid:review_id>/").service_class is ReviewService
     assert _view_class(review_urlpatterns, "<uuid:review_id>/like/").service_class is ReviewService


### PR DESCRIPTION
Closes #4

## Summary

- Added category field to MenuItem
- Added nested menu item CRUD endpoints under restaurants
- Added serializers, service/repository methods, views, URLs, admin support, and tests

## Endpoints

- `GET /api/v1/restaurants/{restaurant_slug}/menu-items/`
- `POST /api/v1/restaurants/{restaurant_slug}/menu-items/`
- `GET /api/v1/restaurants/{restaurant_slug}/menu-items/{menu_item_id}/`
- `PATCH /api/v1/restaurants/{restaurant_slug}/menu-items/{menu_item_id}/`
- `DELETE /api/v1/restaurants/{restaurant_slug}/menu-items/{menu_item_id}/`

## Notes
- Public users can list/read menu items.
- Restaurant owners/admins can create, update, and delete menu items.