### PR TITLE
feat(api/rating): calculate and display average rating per restaurant

### DIFF
--- a/apps/api/restaurants/repositories.py
+++ b/apps/api/restaurants/repositories.py
@@ -6,8 +6,11 @@ from restaurants.models import Category, MenuItem, OpeningHour, Restaurant
 class RestaurantRepository:
     """Repository for restaurant persistence and queries."""
 
-    def list_restaurants(self):
-        return Restaurant.objects.prefetch_related("categories", "opening_hours").all()
+    def list_restaurants(self, sort: str | None = None):
+        qs = Restaurant.objects.prefetch_related("categories", "opening_hours")
+        if sort == "rating":
+            qs = qs.order_by("-average_rating", "-review_count")
+        return qs
 
     def list_categories(self):
         return Category.objects.all()

--- a/apps/api/restaurants/services.py
+++ b/apps/api/restaurants/services.py
@@ -13,8 +13,8 @@ class RestaurantService:
     def __init__(self, repository: RestaurantRepository | None = None) -> None:
         self.repository = repository or self.repository_class()
 
-    def list_restaurants(self):
-        return self.repository.list_restaurants()
+    def list_restaurants(self, sort: str | None = None):
+        return self.repository.list_restaurants(sort=sort)
 
     def list_categories(self):
         return self.repository.list_categories()

--- a/apps/api/restaurants/views.py
+++ b/apps/api/restaurants/views.py
@@ -67,7 +67,8 @@ class RestaurantsController(APIView):
         tags=["Restaurants"],
     )
     def get(self, request):
-        queryset = self.get_service().list_restaurants()
+        sort = request.query_params.get("sort")
+        queryset = self.get_service().list_restaurants(sort=sort)
         page_obj, pagination = paginate_queryset(queryset, request)
 
         include_fields = parse_csv_param(request.query_params.get("include"))

--- a/apps/api/reviews/apps.py
+++ b/apps/api/reviews/apps.py
@@ -5,3 +5,5 @@ class ReviewsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "reviews"
     verbose_name = "Reviews"
+    def ready(self):
+        import reviews.signals  # noqa: F401

--- a/apps/api/reviews/signals.py
+++ b/apps/api/reviews/signals.py
@@ -8,12 +8,12 @@ from reviews.models import Review
 
 @receiver(post_save, sender=Review)
 def on_review_save(sender, instance, **kwargs):
-    if instance.parent is None:
+    if instance.parent_id is None:
         _update_restaurant_rating(instance.restaurant)
 
 @receiver(post_delete, sender=Review)
 def on_review_delete(sender, instance, **kwargs):
-    if instance.parent is None:
+    if instance.parent_id is None:
         _update_restaurant_rating(instance.restaurant)
 
 def _update_restaurant_rating(restaurant):

--- a/apps/api/reviews/signals.py
+++ b/apps/api/reviews/signals.py
@@ -1,0 +1,29 @@
+"""Signals to keep Restaurant rating stats in sync with reviews."""
+
+from django.db.models import Avg, Count
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from reviews.models import Review
+
+@receiver(post_save, sender=Review)
+def on_review_save(sender, instance, **kwargs):
+    if instance.parent is None:
+        _update_restaurant_rating(instance.restaurant)
+
+@receiver(post_delete, sender=Review)
+def on_review_delete(sender, instance, **kwargs):
+    if instance.parent is None:
+        _update_restaurant_rating(instance.restaurant)
+
+def _update_restaurant_rating(restaurant):
+    result = Review.objects.filter(
+        restaurant=restaurant,
+        parent__isnull=True,  
+    ).aggregate(
+        avg=Avg("rating"),
+        count=Count("id"),
+    )
+    restaurant.average_rating = round(result["avg"] or 0, 2)
+    restaurant.review_count = result["count"] or 0
+    restaurant.save(update_fields=["average_rating", "review_count"])


### PR DESCRIPTION
## Summary
Closes #8 

Implements average rating calculation and display per restaurant.

## Changes
- Added `signals.py` to auto-update `average_rating` and `review_count` on the `Restaurant` model whenever a review is created or deleted
- Registered signals in `reviews/apps.py` via the `ready()` method
- Added `?sort=rating` query param support to the restaurant list endpoint

## How it works
- When a review is saved or deleted, a Django signal fires and recalculates the average rating and review count directly from the DB using `Avg` and `Count`
- Results are stored back on the `Restaurant` model for fast reads
- Sorting by rating is handled at the repository level using `order_by("-average_rating", "-review_count")`