### PR TITLE
feat(api): add advanced restaurant filtering

### DIFF
--- a/apps/api/restaurants/repositories.py
+++ b/apps/api/restaurants/repositories.py
@@ -6,8 +6,31 @@ from restaurants.models import Category, MenuItem, OpeningHour, Restaurant
 class RestaurantRepository:
     """Repository for restaurant persistence and queries."""
 
-    def list_restaurants(self):
-        return Restaurant.objects.prefetch_related("categories", "opening_hours").all()
+    def list_restaurants(self, filters: dict | None = None):
+        queryset = Restaurant.objects.prefetch_related("categories", "opening_hours").all()
+        filters = filters or {}
+
+        category = filters.get("category")
+        city = filters.get("city")
+        price_range = filters.get("price_range")
+        min_rating = filters.get("min_rating")
+
+        if category:
+            queryset = queryset.filter(categories__slug=category)
+
+        if city:
+            queryset = queryset.filter(city__iexact=city)
+
+        if price_range:
+            queryset = queryset.filter(price_range=price_range)
+
+        if min_rating is not None:
+            queryset = queryset.filter(average_rating__gte=min_rating)
+
+        if category:
+            queryset = queryset.distinct()
+
+        return queryset
 
     def list_categories(self):
         return Category.objects.all()

--- a/apps/api/restaurants/services.py
+++ b/apps/api/restaurants/services.py
@@ -1,5 +1,7 @@
 """Restaurant application services."""
 
+from decimal import Decimal, InvalidOperation
+
 from api.exceptions import ApiError
 from restaurants.repositories import RestaurantRepository
 from users.models import UserRole
@@ -13,8 +15,53 @@ class RestaurantService:
     def __init__(self, repository: RestaurantRepository | None = None) -> None:
         self.repository = repository or self.repository_class()
 
-    def list_restaurants(self):
-        return self.repository.list_restaurants()
+    def list_restaurants(self, filters: dict | None = None):
+        normalized_filters = self._normalize_restaurant_filters(filters or {})
+        return self.repository.list_restaurants(normalized_filters)
+
+    def _normalize_restaurant_filters(self, filters: dict) -> dict:
+        normalized: dict = {}
+
+        category = filters.get("category")
+        if category:
+            normalized["category"] = str(category).strip().lower()
+
+        city = filters.get("city")
+        if city:
+            normalized["city"] = str(city).strip()
+
+        price_range = filters.get("price_range") or filters.get("price")
+        if price_range:
+            price_range = str(price_range).strip()
+            if price_range not in {"1", "2", "3"}:
+                raise ApiError(
+                    status_code=400,
+                    code="invalid_filter",
+                    detail="price must be one of: 1, 2, 3.",
+                )
+            normalized["price_range"] = price_range
+
+        min_rating = filters.get("min_rating")
+        if min_rating not in (None, ""):
+            try:
+                min_rating_value = Decimal(str(min_rating))
+            except (InvalidOperation, ValueError):
+                raise ApiError(
+                    status_code=400,
+                    code="invalid_filter",
+                    detail="min_rating must be a number between 0 and 5.",
+                ) from None
+
+            if min_rating_value < 0 or min_rating_value > 5:
+                raise ApiError(
+                    status_code=400,
+                    code="invalid_filter",
+                    detail="min_rating must be a number between 0 and 5.",
+                )
+
+            normalized["min_rating"] = min_rating_value
+
+        return normalized
 
     def list_categories(self):
         return self.repository.list_categories()

--- a/apps/api/restaurants/views.py
+++ b/apps/api/restaurants/views.py
@@ -33,8 +33,8 @@ class RestaurantsController(APIView):
     @extend_schema(
         summary="List restaurants",
         description=(
-            "Retrieve a paginated list of restaurants. Supports field filtering and "
-            "relation expansion through query parameters."
+            "Retrieve a paginated list of restaurants. Supports field filtering, "
+            "advanced restaurant filters, and relation expansion through query parameters."
         ),
         parameters=[
             OpenApiParameter(
@@ -62,12 +62,44 @@ class RestaurantsController(APIView):
                 OpenApiTypes.STR,
                 description="Comma-separated list of fields to exclude from the response.",
             ),
+            OpenApiParameter(
+                "category",
+                OpenApiTypes.STR,
+                description="Filter restaurants by category slug.",
+            ),
+            OpenApiParameter(
+                "city",
+                OpenApiTypes.STR,
+                description="Filter restaurants by city. Case-insensitive.",
+            ),
+            OpenApiParameter(
+                "price",
+                OpenApiTypes.STR,
+                description="Filter restaurants by price range: 1, 2, or 3.",
+            ),
+            OpenApiParameter(
+                "price_range",
+                OpenApiTypes.STR,
+                description="Alias for price. Filter restaurants by price range: 1, 2, or 3.",
+            ),
+            OpenApiParameter(
+                "min_rating",
+                OpenApiTypes.NUMBER,
+                description="Filter restaurants with average rating greater than or equal to this value.",
+            ),
         ],
         responses={200: RestaurantSerializer(many=True)},
         tags=["Restaurants"],
     )
     def get(self, request):
-        queryset = self.get_service().list_restaurants()
+        filters = {
+            "category": request.query_params.get("category"),
+            "city": request.query_params.get("city"),
+            "price": request.query_params.get("price"),
+            "price_range": request.query_params.get("price_range"),
+            "min_rating": request.query_params.get("min_rating"),
+        }
+        queryset = self.get_service().list_restaurants(filters)
         page_obj, pagination = paginate_queryset(queryset, request)
 
         include_fields = parse_csv_param(request.query_params.get("include"))


### PR DESCRIPTION
## Summary
- Added advanced filtering to the restaurant list endpoint.
- Supports category, city, price/price_range, and min_rating query parameters.
- Filters combine with AND logic.
- Added validation for invalid price and min_rating values.

## Example
GET /api/v1/restaurants/?category=italian&city=Istanbul&price=2&min_rating=4

## Implementation
- views.py reads query parameters.
- services.py validates and normalizes filters.
- repositories.py applies Django ORM filters.

## Checks
- python3 -m compileall apps/api/restaurants
- poetry run python manage.py check