### PR TITLE
feat(restaurants): add primary photo support

### DIFF
--- a/apps/api/files/services.py
+++ b/apps/api/files/services.py
@@ -51,15 +51,18 @@ class FileService:
             entity_id=entity_id,
             content_type=content_type,
         )
-        
-        # Create database record
-        record = self.repository.create(
-            path=stored.path,
-            category=category,
-            entity_id=entity_id,
-            content_type=content_type,
-            size=getattr(file, "size", None),
-        )
+
+        try:
+            record = self.repository.create(
+                path=stored.path,
+                category=category,
+                entity_id=entity_id,
+                content_type=content_type,
+                size=getattr(file, "size", None),
+            )
+        except Exception:
+            self.storage.delete(stored.path)
+            raise
 
         if not generate_thumbnails:
             return record.id, stored

--- a/apps/api/restaurants/migrations/0006_rename_restaurant_logo_to_primary_photo.py
+++ b/apps/api/restaurants/migrations/0006_rename_restaurant_logo_to_primary_photo.py
@@ -1,0 +1,19 @@
+# Generated manually for restaurant photo support.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("restaurants", "0005_remove_restaurant_category_restaurant_categories"),
+        ("files", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="restaurant",
+            old_name="logo",
+            new_name="primary_photo",
+        ),
+    ]

--- a/apps/api/restaurants/migrations/0007_alter_restaurant_primary_photo.py
+++ b/apps/api/restaurants/migrations/0007_alter_restaurant_primary_photo.py
@@ -1,0 +1,26 @@
+# Generated manually to align the renamed restaurant photo field with the model.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("files", "0001_initial"),
+        ("restaurants", "0006_rename_restaurant_logo_to_primary_photo"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="restaurant",
+            name="primary_photo",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="restaurant_primary_photos",
+                to="files.storedfile",
+            ),
+        ),
+    ]

--- a/apps/api/restaurants/models.py
+++ b/apps/api/restaurants/models.py
@@ -78,12 +78,12 @@ class Restaurant(models.Model):
         blank=True,
         related_name="owned_restaurants",
     )
-    logo = models.ForeignKey(
+    primary_photo = models.ForeignKey(
         "files.StoredFile",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name="restaurant_logos",
+        related_name="restaurant_primary_photos",
     )
 
     address_line1 = models.CharField(max_length=255)

--- a/apps/api/restaurants/serializers.py
+++ b/apps/api/restaurants/serializers.py
@@ -96,7 +96,7 @@ class RestaurantSerializer(DynamicFieldsModelSerializer):
 
     categories = CategorySerializer(many=True, read_only=True)
     opening_hours = OpeningHourSerializer(many=True, read_only=True)
-    logo_url = serializers.SerializerMethodField()
+    primary_photo_url = serializers.SerializerMethodField()
 
     class Meta:
         model = Restaurant
@@ -109,8 +109,7 @@ class RestaurantSerializer(DynamicFieldsModelSerializer):
             "website",
             "categories",
             "opening_hours",
-            "logo",
-            "logo_url",
+            "primary_photo_url",
             "address_line1",
             "address_line2",
             "city",
@@ -125,10 +124,10 @@ class RestaurantSerializer(DynamicFieldsModelSerializer):
             "updated_at",
         ]
 
-    def get_logo_url(self, obj) -> str | None:
-        if not obj.logo_id:
+    def get_primary_photo_url(self, obj) -> str | None:
+        if not obj.primary_photo_id:
             return None
-        return create_file_service().get_obfuscated_url(obj.logo_id)
+        return create_file_service().get_obfuscated_url(obj.primary_photo_id)
 
 
 class RestaurantWriteSerializer(serializers.ModelSerializer):
@@ -141,6 +140,7 @@ class RestaurantWriteSerializer(serializers.ModelSerializer):
         required=True,
     )
     opening_hours = OpeningHourSerializer(many=True, required=False)
+    primary_photo = serializers.ImageField(required=False, allow_null=True, write_only=True)
 
     class Meta:
         model = Restaurant
@@ -151,7 +151,7 @@ class RestaurantWriteSerializer(serializers.ModelSerializer):
             "website",
             "category_ids",
             "opening_hours",
-            "logo",
+            "primary_photo",
             "address_line1",
             "address_line2",
             "city",
@@ -165,6 +165,7 @@ class RestaurantWriteSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         categories = validated_data.pop("categories", [])
         opening_hours_data = validated_data.pop("opening_hours", [])
+        primary_photo = validated_data.pop("primary_photo", None)
         restaurant = Restaurant.objects.create(**validated_data)
 
         if categories:
@@ -175,6 +176,9 @@ class RestaurantWriteSerializer(serializers.ModelSerializer):
                 OpeningHour(restaurant=restaurant, **hour_data)
                 for hour_data in opening_hours_data
             ])
+
+        if primary_photo is not None:
+            self._set_primary_photo(restaurant, primary_photo)
 
         return restaurant
 
@@ -203,12 +207,13 @@ class RestaurantUpdateSerializer(RestaurantWriteSerializer):
             "latitude": {"required": False},
             "longitude": {"required": False},
             "price_range": {"required": False},
-            "logo": {"required": False},
+            "primary_photo": {"required": False},
         }
 
     def update(self, instance, validated_data):
         categories = validated_data.pop("categories", None)
         opening_hours_data = validated_data.pop("opening_hours", None)
+        primary_photo = validated_data.pop("primary_photo", None)
 
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
@@ -224,4 +229,22 @@ class RestaurantUpdateSerializer(RestaurantWriteSerializer):
                 for hour_data in opening_hours_data
             ])
 
+        if primary_photo is not None:
+            self._set_primary_photo(instance, primary_photo)
+
         return instance
+
+    def _set_primary_photo(self, restaurant, uploaded_file) -> None:
+        file_service = create_file_service()
+        previous_photo_id = restaurant.primary_photo_id
+        stored_file_id, _ = file_service.save(
+            uploaded_file,
+            category="restaurants",
+            entity_id=str(restaurant.id),
+            content_type=getattr(uploaded_file, "content_type", "application/octet-stream"),
+        )
+        restaurant.primary_photo_id = stored_file_id
+        restaurant.save(update_fields=["primary_photo", "updated_at"])
+
+        if previous_photo_id and previous_photo_id != stored_file_id:
+            file_service.delete_by_id(previous_photo_id)

--- a/apps/api/restaurants/services.py
+++ b/apps/api/restaurants/services.py
@@ -1,6 +1,9 @@
 """Restaurant application services."""
 
+from django.db import transaction
+
 from api.exceptions import ApiError
+from files.services import create_file_service
 from restaurants.repositories import RestaurantRepository
 from users.models import UserRole
 
@@ -12,6 +15,7 @@ class RestaurantService:
 
     def __init__(self, repository: RestaurantRepository | None = None) -> None:
         self.repository = repository or self.repository_class()
+        self.file_service = create_file_service()
 
     def list_restaurants(self):
         return self.repository.list_restaurants()
@@ -42,11 +46,21 @@ class RestaurantService:
                 detail="You do not have permission to create a restaurant.",
             )
 
+        categories = data.pop("categories", [])
         opening_hours = data.pop("opening_hours", [])
-        restaurant = self.repository.create(owner=user, data=data)
+        primary_photo = data.pop("primary_photo", None)
 
-        if opening_hours:
-            self.repository.set_opening_hours(restaurant, opening_hours)
+        with transaction.atomic():
+            restaurant = self.repository.create(owner=user, data=data)
+
+            if categories:
+                restaurant.categories.set(categories)
+
+            if opening_hours:
+                self.repository.set_opening_hours(restaurant, opening_hours)
+
+            if primary_photo is not None:
+                self._set_primary_photo(restaurant=restaurant, uploaded_file=primary_photo)
 
         return restaurant
 
@@ -58,11 +72,24 @@ class RestaurantService:
                 detail="You do not have permission to update this restaurant.",
             )
 
+        categories = data.pop("categories", None)
         opening_hours = data.pop("opening_hours", None)
-        updated_restaurant = self.repository.save(restaurant, data)
+        primary_photo = data.pop("primary_photo", None)
 
-        if opening_hours is not None:
-            self.repository.set_opening_hours(updated_restaurant, opening_hours)
+        with transaction.atomic():
+            updated_restaurant = self.repository.save(restaurant, data)
+
+            if categories is not None:
+                updated_restaurant.categories.set(categories)
+
+            if opening_hours is not None:
+                self.repository.set_opening_hours(updated_restaurant, opening_hours)
+
+            if primary_photo is not None:
+                self._set_primary_photo(
+                    restaurant=updated_restaurant,
+                    uploaded_file=primary_photo,
+                )
 
         return updated_restaurant
 
@@ -73,6 +100,7 @@ class RestaurantService:
                 code="forbidden",
                 detail="You do not have permission to delete this restaurant.",
             )
+        self._delete_primary_photo(restaurant)
         self.repository.delete(restaurant)
 
     def list_menu_items(self, restaurant):
@@ -109,3 +137,28 @@ class RestaurantService:
             code="forbidden",
             detail="You do not have permission to manage this restaurant menu.",
         )
+
+    def _set_primary_photo(self, *, restaurant, uploaded_file) -> None:
+        previous_photo_id = restaurant.primary_photo_id
+        stored_file_id = None
+
+        try:
+            stored_file_id, _ = self.file_service.save(
+                uploaded_file,
+                category="restaurants",
+                entity_id=str(restaurant.id),
+                content_type=getattr(uploaded_file, "content_type", "application/octet-stream"),
+            )
+            restaurant.primary_photo_id = stored_file_id
+            restaurant.save(update_fields=["primary_photo", "updated_at"])
+        except Exception:
+            if stored_file_id is not None:
+                self.file_service.delete_by_id(stored_file_id)
+            raise
+
+        if previous_photo_id and previous_photo_id != stored_file_id:
+            self.file_service.delete_by_id(previous_photo_id)
+
+    def _delete_primary_photo(self, restaurant) -> None:
+        if restaurant.primary_photo_id:
+            self.file_service.delete_by_id(restaurant.primary_photo_id)

--- a/apps/api/restaurants/tests.py
+++ b/apps/api/restaurants/tests.py
@@ -1,10 +1,15 @@
 """Tests for restaurant endpoints with guards and authentication."""
 
+import io
 import uuid
 
 import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
+from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
+from django.test.utils import override_settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
 
 from restaurants.models import Category, MenuItem, Restaurant
 from users.models import UserRole
@@ -49,6 +54,111 @@ def _create_restaurant(owner=None, slug=None):
     )
     restaurant.categories.set([category])
     return restaurant
+
+
+def _image_upload(name: str = "restaurant-photo.png", format_name: str = "PNG"):
+    buffer = io.BytesIO()
+    Image.new("RGB", (320, 240), color=(24, 48, 72)).save(buffer, format=format_name)
+    buffer.seek(0)
+    content_type = "image/png" if format_name == "PNG" else "image/jpeg"
+    return SimpleUploadedFile(name, buffer.read(), content_type=content_type)
+
+
+def test_restaurant_create_accepts_primary_photo_upload(tmp_path):
+    """POST /restaurants/ supports multipart restaurant photo uploads."""
+    client = Client()
+    owner = _create_user(role=UserRole.OWNER)
+    category = _create_category()
+
+    with override_settings(
+        FILE_STORAGE_LOCAL_ROOT=str(tmp_path),
+        FILE_STORAGE_LOCAL_URL="/media/",
+    ):
+        try:
+            client.force_login(owner)
+            response = client.generic(
+                "POST",
+                "/api/v1/restaurants/",
+                data=encode_multipart(
+                    BOUNDARY,
+                    {
+                        "name": "Ada Bistro",
+                        "category_ids": [str(category.id)],
+                        "description": "Seasonal plates",
+                        "address_line1": "Main Street 1",
+                        "city": "Istanbul",
+                        "district": "Kadikoy",
+                        "phone": "+90 555 0101",
+                        "website": "https://ada.example.com",
+                        "price_range": "2",
+                        "primary_photo": _image_upload(),
+                    },
+                ),
+                content_type=MULTIPART_CONTENT,
+            )
+
+            assert response.status_code == 201
+            created = response.json()["data"]
+            assert created["primary_photo_url"].startswith("/api/v1/files/")
+
+            restaurant = Restaurant.objects.get(slug=created["slug"])
+            assert restaurant.primary_photo_id is not None
+        finally:
+            owner.delete()
+            category.delete()
+
+
+def test_restaurant_update_replaces_primary_photo(tmp_path):
+    """PATCH /restaurants/{slug}/ replaces the primary photo via multipart upload."""
+    client = Client()
+    owner = _create_user(role=UserRole.OWNER)
+    restaurant = _create_restaurant(owner=owner)
+    category = restaurant.categories.first()
+
+    with override_settings(
+        FILE_STORAGE_LOCAL_ROOT=str(tmp_path),
+        FILE_STORAGE_LOCAL_URL="/media/",
+    ):
+        try:
+            client.force_login(owner)
+            create_response = client.generic(
+                "PATCH",
+                f"/api/v1/restaurants/{restaurant.slug}/",
+                data=encode_multipart(
+                    BOUNDARY,
+                    {
+                        "category_ids": [str(category.id)],
+                        "primary_photo": _image_upload("restaurant-photo-1.png"),
+                    },
+                ),
+                content_type=MULTIPART_CONTENT,
+            )
+
+            assert create_response.status_code == 200
+            first_photo_url = create_response.json()["data"]["primary_photo_url"]
+            assert first_photo_url.startswith("/api/v1/files/")
+
+            update_response = client.generic(
+                "PATCH",
+                f"/api/v1/restaurants/{restaurant.slug}/",
+                data=encode_multipart(
+                    BOUNDARY,
+                    {
+                        "category_ids": [str(category.id)],
+                        "primary_photo": _image_upload("restaurant-photo-2.png"),
+                    },
+                ),
+                content_type=MULTIPART_CONTENT,
+            )
+
+            assert update_response.status_code == 200
+            updated = update_response.json()["data"]
+            assert updated["primary_photo_url"].startswith("/api/v1/files/")
+            assert updated["primary_photo_url"] != first_photo_url
+        finally:
+            restaurant.delete()
+            category.delete()
+            owner.delete()
 
 def test_restaurant_list_no_auth_required():
     """GET /restaurants/ should not require authentication."""

--- a/apps/api/restaurants/views.py
+++ b/apps/api/restaurants/views.py
@@ -1,6 +1,7 @@
 """Views for restaurant endpoints."""
 
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -26,6 +27,7 @@ class RestaurantsController(APIView):
     """List restaurants or create a new restaurant."""
 
     service_class = RestaurantService
+    parser_classes = [JSONParser, FormParser, MultiPartParser]
 
     def get_service(self) -> RestaurantService:
         return self.service_class()
@@ -241,6 +243,7 @@ class RestaurantDetailController(APIView):
     """Retrieve, update, or delete a restaurant."""
 
     service_class = RestaurantService
+    parser_classes = [JSONParser, FormParser, MultiPartParser]
 
     def get_service(self) -> RestaurantService:
         return self.service_class()

--- a/apps/web/src/app/(auth)/auth/_components/sign-in.tsx
+++ b/apps/web/src/app/(auth)/auth/_components/sign-in.tsx
@@ -48,6 +48,7 @@ export function SignIn({ variant }: SignInProps) {
     try {
       const user = await loginUser({ email, password });
       startTransition(() => router.push(destinationForRole(user.role)));
+      router.refresh();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Unable to sign in.');
     } finally {
@@ -56,7 +57,7 @@ export function SignIn({ variant }: SignInProps) {
   }
 
   return (
-    <main className="grid min-h-screen bg-background lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+    <main className="grid min-h-screen bg-[radial-gradient(circle_at_top_left,oklch(0.98_0.03_85),transparent_34rem),linear-gradient(180deg,oklch(1_0_0),oklch(0.985_0.012_90))] lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
       <section className="flex items-center justify-center px-4 py-8 sm:px-6 lg:px-10">
         <Card className="w-full max-w-md border border-border/70 shadow-sm">
           <CardHeader className="space-y-2">
@@ -170,13 +171,6 @@ export function SignIn({ variant }: SignInProps) {
                 Create one
               </Link>
             </p>
-            <Link
-              href={isBusiness ? '/auth/sign-in' : '/business/sign-in'}
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {isBusiness ? 'Sign in as a reviewer' : 'Restaurant business sign in'}
-              <RiArrowRightLine className="size-3" aria-hidden="true" />
-            </Link>
           </CardFooter>
         </Card>
       </section>

--- a/apps/web/src/app/(auth)/auth/_components/sign-up.tsx
+++ b/apps/web/src/app/(auth)/auth/_components/sign-up.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { startTransition, useState, type FormEvent } from 'react';
+import { startTransition, useState, type FormEvent, type ReactNode } from 'react';
 import {
   Badge,
   Button,
@@ -13,8 +13,15 @@ import {
   CardHeader,
   CardTitle,
   Input,
+  Separator,
 } from 'ui-common';
-import { RiArrowRightLine } from '@remixicon/react';
+import {
+  RiShieldUserLine,
+  RiStore2Line,
+  RiUserAddLine,
+  RiUserSettingsLine,
+  RiUserStarLine,
+} from '@remixicon/react';
 
 import { registerUser } from '../_lib/auth-api';
 import {
@@ -61,6 +68,7 @@ export function SignUp({ variant }: SignUpProps) {
         }),
       );
       startTransition(() => router.push(destinationForRole(user.role)));
+      router.refresh();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Unable to create account.');
     } finally {
@@ -69,13 +77,17 @@ export function SignUp({ variant }: SignUpProps) {
   }
 
   return (
+    <main className="grid min-h-screen bg-[radial-gradient(circle_at_top_right,oklch(0.97_0.03_84),transparent_34rem),linear-gradient(180deg,oklch(1_0_0),oklch(0.985_0.012_90))] lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+      <section className="flex items-center justify-center px-4 py-8 sm:px-6 lg:px-10">
         <Card className="w-full max-w-md border border-border/70 shadow-sm">
           <CardHeader className="space-y-2">
             <Badge variant={isBusiness ? 'secondary' : 'outline'}>
               {isBusiness ? 'Business onboarding' : 'Reviewer onboarding'}
             </Badge>
             <CardTitle className="text-2xl">
-              {isBusiness ? 'Create your restaurant account' : 'Create your reviewer account'}
+              {isBusiness
+                ? 'Create your restaurant account'
+                : 'Create your reviewer account'}
             </CardTitle>
             <CardDescription>
               {isBusiness
@@ -172,7 +184,6 @@ export function SignUp({ variant }: SignUpProps) {
                 {isSubmitting ? 'Creating account...' : 'Create account'}
               </Button>
             </form>
-
           </CardContent>
 
           <CardFooter className="flex-col items-start gap-3 border-t border-border/60 px-4 pt-4">
@@ -185,14 +196,115 @@ export function SignUp({ variant }: SignUpProps) {
                 Sign in
               </Link>
             </p>
-            <Link
-              href={isBusiness ? '/auth/sign-up' : '/business/sign-up'}
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {isBusiness ? 'Create a reviewer account' : 'Register a restaurant business'}
-              <RiArrowRightLine className="size-3" aria-hidden="true" />
-            </Link>
           </CardFooter>
         </Card>
+      </section>
+
+      <aside className="hidden border-l border-border/60 bg-muted/20 lg:flex lg:items-center lg:justify-center">
+        <div className="max-w-md space-y-5 px-10">
+          <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            {isBusiness ? (
+              <RiStore2Line className="size-6" aria-hidden="true" />
+            ) : (
+              <RiShieldUserLine className="size-6" aria-hidden="true" />
+            )}
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              {isBusiness
+                ? 'A cleaner way to manage your listing'
+                : 'Reviews that help people decide'}
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              {isBusiness
+                ? 'Create your restaurant profile once, then keep the listing current with photos, details, and owner replies.'
+                : 'Join the reviewer path to search restaurants, compare details, and leave useful feedback in one place.'}
+            </p>
+          </div>
+
+          <div className="grid gap-3">
+            <StatCard
+              label={isBusiness ? 'Owner tools' : 'Diner tools'}
+              value={isBusiness ? 'Profile, replies, photos' : 'Browse, react, comment'}
+            />
+            <StatCard
+              label="Next step"
+              value={isBusiness ? 'Open your dashboard' : 'Open discovery map'}
+            />
+          </div>
+
+          <Separator />
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <InfoTile
+              icon={
+                isBusiness ? (
+                  <RiUserSettingsLine className="size-4" />
+                ) : (
+                  <RiUserStarLine className="size-4" />
+                )
+              }
+              title={isBusiness ? 'Manage the brand' : 'Trusted opinions'}
+              text={
+                isBusiness
+                  ? 'Keep photos and details in sync.'
+                  : 'Leave feedback that helps others choose.'
+              }
+            />
+            <InfoTile
+              icon={<RiUserAddLine className="size-4" />}
+              title="Faster onboarding"
+              text="One path for each role, without extra detours."
+            />
+            <InfoTile
+              icon={
+                isBusiness ? (
+                  <RiStore2Line className="size-4" />
+                ) : (
+                  <RiShieldUserLine className="size-4" />
+                )
+              }
+              title={isBusiness ? 'Business portal' : 'Reviewer portal'}
+              text={
+                isBusiness
+                  ? 'Ready for restaurant owners.'
+                  : 'Ready for diners and reviewers.'
+              }
+            />
+          </div>
+        </div>
+      </aside>
+    </main>
+  );
+}
+
+function InfoTile({
+  icon,
+  title,
+  text,
+}: {
+  icon: ReactNode;
+  title: string;
+  text: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background p-3">
+      <div className="mb-2 inline-flex size-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        {icon}
+      </div>
+      <p className="text-sm font-medium">{title}</p>
+      <p className="mt-1 text-xs leading-5 text-muted-foreground">{text}</p>
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background p-4">
+      <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 text-sm font-medium leading-6">{value}</p>
+    </div>
   );
 }

--- a/apps/web/src/app/(auth)/auth/_lib/auth-flow.test.ts
+++ b/apps/web/src/app/(auth)/auth/_lib/auth-flow.test.ts
@@ -8,7 +8,7 @@ import {
   roleForAuthVariant,
   usernameFromEmail,
 } from './auth-flow';
-import { getApiBaseUrl } from '@/lib/restaurants';
+import { getApiBaseUrl, resolveApiAssetUrl } from '@/lib/restaurants';
 
 describe('auth-flow utilities', () => {
   it('routes owners to the restaurant dashboard', () => {
@@ -75,5 +75,16 @@ describe('auth-flow utilities', () => {
         configurable: true,
       });
     }
+  });
+
+  it('resolves relative API asset paths against the API base URL', () => {
+    const apiBaseUrl = getApiBaseUrl();
+
+    expect(resolveApiAssetUrl('/api/v1/files/asset-123')).toBe(
+      `${apiBaseUrl}/api/v1/files/asset-123`,
+    );
+    expect(resolveApiAssetUrl('https://media.example.com/photo.jpg')).toBe(
+      'https://media.example.com/photo.jpg',
+    );
   });
 });

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,11 +1,7 @@
-
-
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-    return (
-        <main className="grid min-h-screen bg-background lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-            <section className="flex items-center justify-center px-4 py-8 sm:px-6 lg:px-10">
-                    {children}
-            </section>
-        </main>
-    )
+  return (
+    <main className="min-h-screen bg-background">
+      {children}
+    </main>
+  );
 }

--- a/apps/web/src/app/_components/header.tsx
+++ b/apps/web/src/app/_components/header.tsx
@@ -1,8 +1,46 @@
 
-export function Header() {
-    return <header className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            Flavor Map
+import type { ReactNode } from 'react';
+
+import { cn } from 'ui-common';
+
+type HeaderProps = {
+  title: string;
+  description?: string;
+  eyebrow?: string;
+  action?: ReactNode;
+  className?: string;
+};
+
+export function Header({
+  title,
+  description,
+  eyebrow,
+  action,
+  className,
+}: HeaderProps) {
+  return (
+    <header
+      className={cn(
+        'flex flex-col gap-4 border-b border-border/60 pb-6 md:flex-row md:items-end md:justify-between',
+        className,
+      )}
+    >
+      <div className="space-y-2">
+        {eyebrow ? (
+          <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+          {title}
         </h1>
-    </header>;
+        {description ? (
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {action ? <div className="flex shrink-0">{action}</div> : null}
+    </header>
+  );
 }

--- a/apps/web/src/app/_components/navigation.tsx
+++ b/apps/web/src/app/_components/navigation.tsx
@@ -1,36 +1,295 @@
-import 'ui-common/styles/global.css';
-import { Button } from 'ui-common';
+'use client';
+
 import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { startTransition, useEffect, useState, type ComponentType } from 'react';
+import {
+  Avatar,
+  AvatarFallback,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Spinner,
+  cn,
+} from 'ui-common';
+import {
+  RiDashboardLine,
+  RiLogoutBoxLine,
+  RiRestaurant2Line,
+  RiStore2Line,
+} from '@remixicon/react';
 
+import { logoutUser, getCurrentUser } from '@/app/(auth)/auth/_lib/auth-api';
+import { destinationForRole } from '@/app/(auth)/auth/_lib/auth-flow';
+import { type User } from '@/lib/restaurants';
 
-function NavigationRegisteration() {
-  return (
-    <ul className="flex h-full items-center justify-end gap-2">
-      <li>
-        <Button size="lg" asChild>
-          <Link href="/auth/sign-in">
-            Sign In
-          </Link>
-        </Button>
-      </li>
-      <li>
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/auth/sign-up">
-            Sign Up
-          </Link>
-        </Button>
-      </li>
-    </ul>
-  )
-}
+type NavLink = {
+  href: string;
+  label: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+const navigationLinks: NavLink[] = [
+  {
+    href: '/restaurants',
+    label: 'Restaurants',
+    description: 'Browse reviewed places',
+    icon: RiRestaurant2Line,
+  },
+  {
+    href: '/business/sign-in',
+    label: 'For business',
+    description: 'Manage your listing',
+    icon: RiStore2Line,
+  },
+];
 
 export function Navigation() {
-  return <nav className="mx-auto flex w-full max-w-7xl flex-row items-center justify-between p-6">
-    <h1 className="text-2xl font-bold">
-      <Link href="/">
-        Flavor Map
-      </Link>
-    </h1>
-    <NavigationRegisteration />
-  </nav>;
+  const pathname = usePathname();
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoadingUser, setIsLoadingUser] = useState(true);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadUser() {
+      setIsLoadingUser(true);
+
+      try {
+        const currentUser = await getCurrentUser();
+
+        if (!cancelled) {
+          setUser(currentUser);
+        }
+      } catch {
+        if (!cancelled) {
+          setUser(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingUser(false);
+        }
+      }
+    }
+
+    void loadUser();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname]);
+
+  if (pathname.startsWith('/owner/dashboard') || pathname.startsWith('/auth') || pathname.startsWith('/business')) {
+    return null;
+  }
+
+  const displayName =
+    user?.display_name?.trim() || user?.username || user?.email.split('@')[0] || null;
+  const roleLabel = user ? (user.role === 'owner' ? 'Business account' : 'Reviewer account') : null;
+
+  async function handleSignOut() {
+    setIsSigningOut(true);
+
+    try {
+      await logoutUser();
+      setUser(null);
+      startTransition(() => {
+        router.push('/');
+        router.refresh();
+      });
+    } finally {
+      setIsSigningOut(false);
+    }
+  }
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-border/60 bg-background/92 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+        <Link href="/" className="flex min-w-0 items-center gap-3">
+          <span className="inline-flex size-9 items-center justify-center rounded-xl border border-border/70 bg-background shadow-sm">
+            <RiRestaurant2Line className="size-4" aria-hidden="true" />
+          </span>
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold tracking-tight text-foreground">
+              FlavorMap
+            </span>
+            <span className="block truncate text-[11px] text-muted-foreground">
+              Restaurants and review workflows
+            </span>
+          </span>
+        </Link>
+
+        <nav className="ml-3 hidden items-center gap-1 lg:flex">
+          {navigationLinks.map((link) => (
+            <HeaderLink
+              key={link.href}
+              href={link.href}
+              label={link.label}
+              active={isActive(pathname, link.href)}
+            />
+          ))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-2">
+          <Link
+            href="/restaurants"
+            className="hidden rounded-full border border-border/70 px-3 py-2 text-sm text-muted-foreground transition hover:border-border hover:bg-muted/60 hover:text-foreground md:inline-flex"
+          >
+            Explore restaurants
+          </Link>
+
+          {isLoadingUser ? (
+            <Button variant="ghost" size="sm" className="gap-2 rounded-full" disabled>
+              <Spinner className="size-4" />
+              Account
+            </Button>
+          ) : user ? (
+            <AccountMenu
+              user={user}
+              displayName={displayName}
+              roleLabel={roleLabel}
+              onSignOut={handleSignOut}
+              isSigningOut={isSigningOut}
+              onNavigate={(href) => router.push(href)}
+            />
+          ) : (
+            <div className="flex items-center gap-2">
+              <Button asChild variant="ghost" size="sm" className="rounded-full">
+                <Link href="/auth/sign-in">Sign in</Link>
+              </Button>
+              <Button asChild size="sm" className="rounded-full">
+                <Link href="/auth/sign-up">Create account</Link>
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function HeaderLink({
+  href,
+  label,
+  active,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition hover:bg-muted/60 hover:text-foreground',
+        active && 'bg-foreground text-background hover:bg-foreground hover:text-background',
+      )}
+    >
+      {label}
+    </Link>
+  );
+}
+
+function AccountMenu({
+  user,
+  displayName,
+  roleLabel,
+  onNavigate,
+  onSignOut,
+  isSigningOut,
+}: {
+  user: User;
+  displayName: string | null;
+  roleLabel: string | null;
+  onNavigate: (href: string) => void;
+  onSignOut: () => Promise<void>;
+  isSigningOut: boolean;
+}) {
+  const initials = getInitials(displayName || user.username || user.email);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="h-auto gap-3 rounded-full border border-border/70 px-3 py-2 text-left shadow-sm hover:bg-background"
+        >
+          <Avatar size="sm">
+            <AvatarFallback className="bg-muted text-xs font-semibold text-foreground">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <span className="hidden min-w-0 sm:block">
+            <span className="block truncate text-sm font-medium text-foreground">
+              {displayName}
+            </span>
+            <span className="block truncate text-[11px] text-muted-foreground">
+              {roleLabel}
+            </span>
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuLabel>
+          <div className="space-y-0.5">
+            <p className="text-sm font-medium text-foreground">{displayName}</p>
+            <p className="text-xs text-muted-foreground">{user.email}</p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => onNavigate('/restaurants')}>
+          <RiRestaurant2Line className="size-4" aria-hidden="true" />
+          Restaurants
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={() =>
+            onNavigate(user.role === 'owner' ? '/owner/dashboard' : destinationForRole(user.role))
+          }
+        >
+          <RiDashboardLine className="size-4" aria-hidden="true" />
+          {user.role === 'owner' ? 'Owner dashboard' : 'My restaurants'}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onSelect={(event) => {
+            event.preventDefault();
+            void onSignOut();
+          }}
+          disabled={isSigningOut}
+        >
+          <RiLogoutBoxLine className="size-4" aria-hidden="true" />
+          {isSigningOut ? 'Signing out...' : 'Sign out'}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === '/restaurants' && pathname.startsWith('/restaurants')) {
+    return true;
+  }
+
+  return pathname === href;
+}
+
+function getInitials(value: string): string {
+  return (
+    value
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase() ?? '')
+      .join('')
+      .slice(0, 2) || 'FM'
+  );
 }

--- a/apps/web/src/app/owner/dashboard/_components/owner-dashboard.tsx
+++ b/apps/web/src/app/owner/dashboard/_components/owner-dashboard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useState, type FormEvent, type ReactNode } from 'react';
 import {
+  AspectRatio,
   Badge,
   Button,
   Card,
@@ -41,6 +42,8 @@ import {
   type Restaurant,
   type RestaurantCategory,
   type User,
+  getRestaurantImageUrl,
+  resolveApiAssetUrl,
 } from '@/lib/restaurants';
 import {
   fetchRestaurantReviews,
@@ -48,7 +51,7 @@ import {
   type Review,
 } from '@/lib/reviews';
 import {
-  buildRestaurantWritePayload,
+  buildRestaurantWriteFormData,
   emptyRestaurantFormValues,
   restaurantToFormValues,
   type RestaurantFormValues,
@@ -67,7 +70,9 @@ export function OwnerDashboard() {
   const [editingSlug, setEditingSlug] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loadWarning, setLoadWarning] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let ignore = false;
@@ -75,6 +80,7 @@ export function OwnerDashboard() {
     async function loadDashboard() {
       setLoadState('loading');
       setError(null);
+      setLoadWarning(null);
 
       try {
         const currentUser = await sessionRequest<User>(API_ENDPOINTS.auth.me());
@@ -89,7 +95,7 @@ export function OwnerDashboard() {
           return;
         }
 
-        const [ownedRestaurants, categoryList] = await Promise.all([
+        const [restaurantsResult, categoriesResult] = await Promise.allSettled([
           sessionRequest<Restaurant[]>(API_ENDPOINTS.restaurants.mine()),
           sessionRequest<RestaurantCategory[]>(API_ENDPOINTS.categories.list()),
         ]);
@@ -98,12 +104,28 @@ export function OwnerDashboard() {
           return;
         }
 
-        setRestaurants(ownedRestaurants);
-        setCategories(categoryList.filter((category) => category.id));
-        setFormValues((current) => ({
-          ...current,
-          categoryId: current.categoryId || categoryList[0]?.id || '',
-        }));
+        if (restaurantsResult.status === 'fulfilled') {
+          setRestaurants(restaurantsResult.value);
+        } else {
+          setRestaurants([]);
+          setLoadWarning((current) =>
+            current ?? 'We could not load your restaurant list right now.',
+          );
+        }
+
+        if (categoriesResult.status === 'fulfilled') {
+          const categoryList = categoriesResult.value.filter((category) => category.id);
+          setCategories(categoryList);
+          setFormValues((current) => ({
+            ...current,
+            categoryId: current.categoryId || categoryList[0]?.id || '',
+          }));
+        } else {
+          setCategories([]);
+          setLoadWarning((current) =>
+            current ?? 'We could not load restaurant categories right now.',
+          );
+        }
         setLoadState('ready');
       } catch (caught) {
         if (ignore) {
@@ -121,6 +143,18 @@ export function OwnerDashboard() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!formValues.primaryPhotoFile) {
+      setPhotoPreviewUrl(null);
+      return;
+    }
+
+    const previewUrl = URL.createObjectURL(formValues.primaryPhotoFile);
+    setPhotoPreviewUrl(previewUrl);
+
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [formValues.primaryPhotoFile]);
+
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setIsSubmitting(true);
@@ -128,17 +162,15 @@ export function OwnerDashboard() {
     setMessage(null);
 
     try {
-      const payload = buildRestaurantWritePayload(formValues);
+      const payload = buildRestaurantWriteFormData(formValues);
       const savedRestaurant = editingSlug
         ? await sessionRequest<Restaurant>(API_ENDPOINTS.restaurants.update(editingSlug), {
             method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
+            body: payload,
           })
         : await sessionRequest<Restaurant>(API_ENDPOINTS.restaurants.create(), {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
+            body: payload,
           });
 
       setRestaurants((current) => {
@@ -238,6 +270,10 @@ export function OwnerDashboard() {
     ? restaurants.find((restaurant) => restaurant.slug === editingSlug)
     : restaurants[0];
   const detailRestaurant = activeRestaurant ?? restaurants[0];
+  const previewImageUrl =
+    photoPreviewUrl ||
+    resolveApiAssetUrl(detailRestaurant?.primary_photo_url) ||
+    (detailRestaurant ? getRestaurantImageUrl(detailRestaurant) : null);
 
   return (
     <main className="min-h-screen bg-[#f7f8fb] text-foreground">
@@ -301,10 +337,32 @@ export function OwnerDashboard() {
                   </CardHeader>
                   <CardContent className="divide-y divide-border/70 px-0">
                     <div className="space-y-4 px-5 py-4">
+                      <div className="overflow-hidden rounded-2xl border border-border/70 bg-muted/20">
+                        <AspectRatio ratio={16 / 10}>
+                          {previewImageUrl ? (
+                            <img
+                              src={previewImageUrl}
+                              alt={detailRestaurant?.name || 'Restaurant preview'}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-[linear-gradient(135deg,oklch(0.98_0.01_90),oklch(0.94_0.02_86))] text-muted-foreground">
+                              <RiImageLine className="size-12" aria-hidden="true" />
+                            </div>
+                          )}
+                        </AspectRatio>
+                      </div>
                       <DetailRow label="Restaurant name" value={detailRestaurant?.name || 'Not created yet'} />
                       <DetailRow label="Category" value={detailRestaurant?.category?.name || 'Select category'} />
                       <DetailRow label="City" value={detailRestaurant?.city || formValues.city || 'Istanbul'} />
                       <DetailRow label="District" value={detailRestaurant?.district || formValues.district || 'Not set'} />
+                      <DetailRow
+                        label="Photo"
+                        value={
+                          formValues.primaryPhotoFile?.name ||
+                          (detailRestaurant?.primary_photo_url ? 'Current primary photo' : 'Upload a photo')
+                        }
+                      />
                     </div>
                     <div className="space-y-4 px-5 py-4">
                       <DetailRow label="Rating" value={totalReviews ? weightedRating.toFixed(1) : 'No reviews'} />
@@ -354,7 +412,7 @@ export function OwnerDashboard() {
                   />
                 </section>
 
-                <section className="grid gap-4 lg:grid-cols-[minmax(0,1.08fr)_minmax(300px,0.92fr)]">
+            <section className="grid gap-4 lg:grid-cols-[minmax(0,1.08fr)_minmax(300px,0.92fr)]">
         <Card className="border border-border/70 bg-card shadow-sm">
           <CardHeader className="space-y-1">
             <CardTitle>{editingSlug ? 'Edit listing' : 'Create a listing'}</CardTitle>
@@ -367,6 +425,11 @@ export function OwnerDashboard() {
             </CardDescription>
           </CardHeader>
           <CardContent>
+            {loadWarning && (
+              <p className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                {loadWarning}
+              </p>
+            )}
             <form className="space-y-4" onSubmit={onSubmit}>
               <TextField
                 id="restaurant-name"
@@ -482,6 +545,32 @@ export function OwnerDashboard() {
                   placeholder="https://example.com"
                   disabled={isSubmitting}
                 />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="primary-photo" className="text-xs font-medium">
+                  Primary photo
+                </label>
+                <div className="rounded-xl border border-dashed border-border/80 bg-muted/20 p-4">
+                  <input
+                    id="primary-photo"
+                    type="file"
+                    accept="image/jpeg,image/png,image/webp"
+                    onChange={(event) =>
+                      updateField('primaryPhotoFile', event.target.files?.[0] ?? null)
+                    }
+                    disabled={isSubmitting}
+                    className="block w-full text-sm text-muted-foreground file:mr-4 file:rounded-full file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+                  />
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    JPG, PNG, or WebP. Uploads replace the current front image.
+                  </p>
+                  {(formValues.primaryPhotoFile || formValues.primaryPhotoUrl) && (
+                    <p className="mt-2 text-xs font-medium text-foreground">
+                      {formValues.primaryPhotoFile?.name || 'Existing photo loaded'}
+                    </p>
+                  )}
+                </div>
               </div>
 
               {message && (

--- a/apps/web/src/app/owner/dashboard/_lib/owner-dashboard-utils.test.ts
+++ b/apps/web/src/app/owner/dashboard/_lib/owner-dashboard-utils.test.ts
@@ -2,54 +2,52 @@ import { describe, expect, it } from 'vitest';
 
 import type { Restaurant } from '@/lib/restaurants';
 import {
-  buildRestaurantWritePayload,
+  buildRestaurantWriteFormData,
   emptyRestaurantFormValues,
   restaurantToFormValues,
 } from './owner-dashboard-utils';
 
 describe('owner dashboard utilities', () => {
-  it('creates a compact write payload from form values', () => {
-    expect(
-      buildRestaurantWritePayload({
-        name: '  Ada Bistro  ',
-        categoryId: 'cat-1',
-        description: '  Seasonal plates  ',
-        addressLine1: '  Main Street 1  ',
-        city: '  Istanbul  ',
-        district: '  Kadikoy  ',
-        phone: '  +90 555 0101  ',
-        website: '  https://ada.example.com  ',
-        priceRange: '2',
-      }),
-    ).toEqual({
-      name: 'Ada Bistro',
-      category_id: 'cat-1',
-      description: 'Seasonal plates',
-      address_line1: 'Main Street 1',
-      city: 'Istanbul',
-      district: 'Kadikoy',
-      phone: '+90 555 0101',
-      website: 'https://ada.example.com',
-      price_range: '2',
+  it('creates a multipart payload from form values', () => {
+    const formData = buildRestaurantWriteFormData({
+      name: '  Ada Bistro  ',
+      categoryId: 'cat-1',
+      description: '  Seasonal plates  ',
+      addressLine1: '  Main Street 1  ',
+      city: '  Istanbul  ',
+      district: '  Kadikoy  ',
+      phone: '  +90 555 0101  ',
+      website: '  https://ada.example.com  ',
+      priceRange: '2',
+      primaryPhotoFile: null,
+      primaryPhotoUrl: '',
     });
+
+    expect(formData.get('name')).toBe('Ada Bistro');
+    expect(formData.get('category_ids')).toBe('cat-1');
+    expect(formData.get('description')).toBe('Seasonal plates');
+    expect(formData.get('address_line1')).toBe('Main Street 1');
+    expect(formData.get('city')).toBe('Istanbul');
+    expect(formData.get('district')).toBe('Kadikoy');
+    expect(formData.get('phone')).toBe('+90 555 0101');
+    expect(formData.get('website')).toBe('https://ada.example.com');
+    expect(formData.get('price_range')).toBe('2');
   });
 
   it('preserves optional blank fields as empty strings for updates', () => {
-    expect(
-      buildRestaurantWritePayload({
-        ...emptyRestaurantFormValues(),
-        name: 'Ada Bistro',
-        categoryId: 'cat-1',
-        description: 'Seasonal plates',
-        addressLine1: 'Main Street 1',
-        city: 'Istanbul',
-      }),
-    ).toMatchObject({
-      district: '',
-      phone: '',
-      website: '',
-      price_range: '2',
+    const formData = buildRestaurantWriteFormData({
+      ...emptyRestaurantFormValues(),
+      name: 'Ada Bistro',
+      categoryId: 'cat-1',
+      description: 'Seasonal plates',
+      addressLine1: 'Main Street 1',
+      city: 'Istanbul',
     });
+
+    expect(formData.get('district')).toBe('');
+    expect(formData.get('phone')).toBe('');
+    expect(formData.get('website')).toBe('');
+    expect(formData.get('price_range')).toBe('2');
   });
 
   it('converts an existing restaurant to editable form values', () => {
@@ -65,6 +63,7 @@ describe('owner dashboard utilities', () => {
       phone: '+90 555 0101',
       website: 'https://ada.example.com',
       price_range: '3',
+      primary_photo_url: 'https://media.example.com/primary-photo.jpg',
     };
 
     expect(restaurantToFormValues(restaurant)).toEqual({
@@ -77,6 +76,8 @@ describe('owner dashboard utilities', () => {
       phone: '+90 555 0101',
       website: 'https://ada.example.com',
       priceRange: '3',
+      primaryPhotoFile: null,
+      primaryPhotoUrl: 'https://media.example.com/primary-photo.jpg',
     });
   });
 });

--- a/apps/web/src/app/owner/dashboard/_lib/owner-dashboard-utils.ts
+++ b/apps/web/src/app/owner/dashboard/_lib/owner-dashboard-utils.ts
@@ -1,4 +1,4 @@
-import type { Restaurant } from '@/lib/restaurants';
+import { resolveApiAssetUrl, type Restaurant } from '@/lib/restaurants';
 
 export type RestaurantFormValues = {
   name: string;
@@ -10,18 +10,8 @@ export type RestaurantFormValues = {
   phone: string;
   website: string;
   priceRange: string;
-};
-
-export type RestaurantWritePayload = {
-  name: string;
-  category_id: string;
-  description: string;
-  address_line1: string;
-  city: string;
-  district: string;
-  phone: string;
-  website: string;
-  price_range: string;
+  primaryPhotoFile: File | null;
+  primaryPhotoUrl: string;
 };
 
 export function emptyRestaurantFormValues(): RestaurantFormValues {
@@ -35,6 +25,8 @@ export function emptyRestaurantFormValues(): RestaurantFormValues {
     phone: '',
     website: '',
     priceRange: '2',
+    primaryPhotoFile: null,
+    primaryPhotoUrl: '',
   };
 }
 
@@ -51,21 +43,28 @@ export function restaurantToFormValues(
     phone: restaurant.phone ?? '',
     website: restaurant.website ?? '',
     priceRange: restaurant.price_range ?? '2',
+    primaryPhotoFile: null,
+    primaryPhotoUrl: resolveApiAssetUrl(restaurant.primary_photo_url),
   };
 }
 
-export function buildRestaurantWritePayload(
+export function buildRestaurantWriteFormData(
   values: RestaurantFormValues,
-): RestaurantWritePayload {
-  return {
-    name: values.name.trim(),
-    category_id: values.categoryId.trim(),
-    description: values.description.trim(),
-    address_line1: values.addressLine1.trim(),
-    city: values.city.trim(),
-    district: values.district.trim(),
-    phone: values.phone.trim(),
-    website: values.website.trim(),
-    price_range: values.priceRange.trim() || '2',
-  };
+): FormData {
+  const formData = new FormData();
+  formData.append('name', values.name.trim());
+  formData.append('category_ids', values.categoryId.trim());
+  formData.append('description', values.description.trim());
+  formData.append('address_line1', values.addressLine1.trim());
+  formData.append('city', values.city.trim());
+  formData.append('district', values.district.trim());
+  formData.append('phone', values.phone.trim());
+  formData.append('website', values.website.trim());
+  formData.append('price_range', values.priceRange.trim() || '2');
+
+  if (values.primaryPhotoFile) {
+    formData.append('primary_photo', values.primaryPhotoFile);
+  }
+
+  return formData;
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,7 +11,7 @@ import { SearchBox } from '@flavor-map/ui-module-discovery';
 
 import {
   buildRestaurantsUrl,
-  getRestaurantCoverImage,
+  getRestaurantImageUrl,
   normalizeRestaurantsResponse,
   type Restaurant,
 } from '@/lib/restaurants';
@@ -215,7 +215,7 @@ function RestaurantCard({ restaurant }: { restaurant: Restaurant }) {
     >
       <div className="relative h-44 overflow-hidden">
         <img
-          src={getRestaurantCoverImage(restaurant.slug)}
+          src={getRestaurantImageUrl(restaurant)}
           alt=""
           className="h-full w-full object-cover"
           loading="lazy"
@@ -248,7 +248,7 @@ function RestaurantPreview({ restaurant }: { restaurant: Restaurant }) {
       className="grid grid-cols-[8rem_minmax(0,1fr)] overflow-hidden rounded-3xl border border-black/5 bg-white shadow-sm transition hover:shadow-xl"
     >
       <img
-        src={getRestaurantCoverImage(restaurant.slug)}
+        src={getRestaurantImageUrl(restaurant)}
         alt=""
         className="h-full min-h-32 w-full object-cover"
         loading="lazy"

--- a/apps/web/src/app/restaurants/[slug]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
 import {
   fetchRestaurantDetail,
   getRestaurantCoverImage,
+  getRestaurantImageUrl,
   getRestaurantDistanceKm,
   getRestaurantIsOpen,
   slugToTitle,
@@ -34,7 +35,7 @@ export default async function RestaurantDetailPage({
   ]);
 
   const displayName = restaurant?.name || slugToTitle(slug);
-  const imageUrl = getRestaurantCoverImage(slug);
+  const imageUrl = restaurant ? getRestaurantImageUrl(restaurant) : getRestaurantCoverImage(slug);
   const distanceKm = getRestaurantDistanceKm(slug);
   const isOpen = getRestaurantIsOpen(slug);
 

--- a/apps/web/src/app/restaurants/_components/explore-map-panel.tsx
+++ b/apps/web/src/app/restaurants/_components/explore-map-panel.tsx
@@ -8,7 +8,6 @@ import {
   CardTitle,
 } from 'ui-common';
 import {
-  RiMapPin2Fill,
   RiRoadMapLine,
   RiFilter3Line,
   RiRouteLine,
@@ -51,21 +50,37 @@ export function ExploreMapPanel({ restaurants, query }: ExploreMapPanelProps) {
         <div className="relative overflow-hidden rounded-xl border border-border/60 bg-[radial-gradient(circle_at_20%_20%,_#f8fbff,_#eef4fa_55%,_#e8eef7_100%)]">
           <div className="absolute inset-0 opacity-70 [background-image:linear-gradient(90deg,transparent_0,transparent_48%,rgba(163,181,205,.22)_50%,transparent_52%,transparent_100%),linear-gradient(180deg,transparent_0,transparent_48%,rgba(163,181,205,.2)_50%,transparent_52%,transparent_100%)] [background-size:54px_54px]" />
 
-          <div className="relative h-72 p-4">
-            {markerPoints.map((point, index) => (
-              <button
-                key={index}
-                type="button"
-                className="absolute inline-flex -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border border-primary/30 bg-primary px-2.5 py-1 text-[11px] font-semibold text-primary-foreground shadow-md"
-                style={{ left: point.left, top: point.top }}
-              >
-                <RiMapPin2Fill className="size-3.5" />
-                {index + 1}
-              </button>
-            ))}
+          <div className="relative flex h-72 flex-col justify-between p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-semibold text-primary">
+                API-backed results
+              </div>
+              <div className="text-[11px] text-muted-foreground">
+                {query ? `Search: "${query}"` : 'Showing nearby restaurants'}
+              </div>
+            </div>
 
-            <div className="absolute right-3 bottom-3 rounded-lg border border-border/70 bg-white/90 p-2 text-[11px] text-muted-foreground shadow-sm backdrop-blur">
-              {query ? `Search: "${query}"` : 'Showing nearby restaurants'}
+            <div className="space-y-2">
+              {restaurants.slice(0, 4).map((restaurant) => (
+                <div
+                  key={restaurant.id}
+                  className="flex items-center justify-between rounded-lg border border-border/60 bg-white/80 px-3 py-2 shadow-sm backdrop-blur"
+                >
+                  <div className="min-w-0">
+                    <p className="line-clamp-1 text-sm font-medium text-foreground">
+                      {restaurant.name}
+                    </p>
+                    <p className="line-clamp-1 text-xs text-muted-foreground">
+                      {[restaurant.city, restaurant.district]
+                        .filter(Boolean)
+                        .join(' • ') || 'Location loaded from API'}
+                    </p>
+                  </div>
+                  <Button asChild size="sm" variant="ghost" className="h-7 px-2 text-xs">
+                    <Link href={`/restaurants/${restaurant.slug}`}>Open</Link>
+                  </Button>
+                </div>
+              ))}
             </div>
           </div>
         </div>
@@ -110,11 +125,3 @@ export function ExploreMapPanel({ restaurants, query }: ExploreMapPanelProps) {
     </Card>
   );
 }
-
-const markerPoints = [
-  { left: '18%', top: '26%' },
-  { left: '34%', top: '62%' },
-  { left: '52%', top: '40%' },
-  { left: '68%', top: '24%' },
-  { left: '80%', top: '68%' },
-];

--- a/apps/web/src/app/restaurants/_components/explore-view.tsx
+++ b/apps/web/src/app/restaurants/_components/explore-view.tsx
@@ -101,29 +101,9 @@ export function ExploreView({ initialQuery, initialPage }: ExploreViewProps) {
 
   return (
     <div className="relative flex h-screen w-full flex-col overflow-hidden bg-background">
-      <SearchBar
-        value={searchParams.get('q') ?? ''}
-        onChange={setInputValue}
-        onSubmit={handleSearchSubmit}
-        onClear={handleSearchClear}
-        activeFilterCount={activeFilterCount}
-        showFilters={showFilters}
-        onToggleFilters={toggleFilters}
-      />
-
-      {showFilters && (
-        <FilterBar
-          filters={filters}
-          activeCount={activeFilterCount}
-          onPriceChange={setPriceFilter}
-          onRatingChange={setRatingFilter}
-          onClearAll={clearAllFilters}
-        />
-      )}
-
-      <div className="relative flex flex-1 flex-col overflow-hidden lg:flex-row">
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
         <div
-          className={`relative h-[42vh] shrink-0 overflow-hidden bg-muted lg:h-auto lg:flex-1 ${
+          className={`relative min-h-[42vh] shrink-0 overflow-hidden bg-muted lg:min-h-0 lg:flex-1 ${
             showListMobile ? 'lg:flex' : 'flex'
           }`}
         >
@@ -135,6 +115,32 @@ export function ExploreView({ initialQuery, initialPage }: ExploreViewProps) {
             onSelect={setSelectedRestaurant}
             query={query}
           />
+
+          <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex flex-col gap-2 sm:inset-x-4 sm:top-4 lg:inset-x-5 lg:top-5">
+            <div className="pointer-events-auto max-w-2xl">
+              <SearchBar
+                value={searchParams.get('q') ?? ''}
+                onChange={setInputValue}
+                onSubmit={handleSearchSubmit}
+                onClear={handleSearchClear}
+                activeFilterCount={activeFilterCount}
+                showFilters={showFilters}
+                onToggleFilters={toggleFilters}
+              />
+            </div>
+
+            {showFilters && (
+              <div className="pointer-events-auto max-w-2xl">
+                <FilterBar
+                  filters={filters}
+                  activeCount={activeFilterCount}
+                  onPriceChange={setPriceFilter}
+                  onRatingChange={setRatingFilter}
+                  onClearAll={clearAllFilters}
+                />
+              </div>
+            )}
+          </div>
         </div>
 
         <RestaurantList

--- a/apps/web/src/app/restaurants/_components/filter-bar.tsx
+++ b/apps/web/src/app/restaurants/_components/filter-bar.tsx
@@ -19,51 +19,51 @@ export function FilterBar({
   onClearAll,
 }: FilterBarProps) {
   return (
-    <div className="relative z-20 flex shrink-0 flex-wrap items-center gap-2 border-b border-border/60 bg-muted/40 px-4 py-2.5">
-      <span className="text-xs font-medium text-muted-foreground">Price:</span>
-      {['1', '2', '3'].map((p) => (
-        <button
-          key={p}
-          type="button"
-          onClick={() => onPriceChange(filters.price === p ? null : p)}
-          className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
-            filters.price === p
-              ? 'border-primary bg-primary text-primary-foreground'
-              : 'border-border/70 bg-background text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-          }`}
-        >
-          {'€'.repeat(Number(p))}
-        </button>
-      ))}
+    <div className="rounded-[1.25rem] border border-border/70 bg-background/92 p-3 shadow-xl shadow-black/5 backdrop-blur-xl">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Price:</span>
+        {['1', '2', '3'].map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onPriceChange(filters.price === p ? null : p)}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              filters.price === p
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border/70 bg-background text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+            }`}
+          >
+            {'€'.repeat(Number(p))}
+          </button>
+        ))}
 
-      <span className="ml-2 text-xs font-medium text-muted-foreground">
-        Rating:
-      </span>
-      {[3, 4, 4.5].map((r) => (
-        <button
-          key={r}
-          type="button"
-          onClick={() => onRatingChange(filters.rating === r ? null : r)}
-          className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
-            filters.rating === r
-              ? 'border-primary bg-primary text-primary-foreground'
-              : 'border-border/70 bg-background text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-          }`}
-        >
-          <RiStarFill className="size-3 text-amber-500" />
-          {r}+
-        </button>
-      ))}
+        <span className="ml-2 text-xs font-medium text-muted-foreground">Rating:</span>
+        {[3, 4, 4.5].map((r) => (
+          <button
+            key={r}
+            type="button"
+            onClick={() => onRatingChange(filters.rating === r ? null : r)}
+            className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              filters.rating === r
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border/70 bg-background text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+            }`}
+          >
+            <RiStarFill className="size-3 text-amber-500" />
+            {r}+
+          </button>
+        ))}
 
-      {activeCount > 0 && (
-        <button
-          type="button"
-          onClick={onClearAll}
-          className="ml-auto text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
-        >
-          Clear all
-        </button>
-      )}
+        {activeCount > 0 && (
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="ml-auto text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/restaurants/_components/map-panel.tsx
+++ b/apps/web/src/app/restaurants/_components/map-panel.tsx
@@ -18,22 +18,7 @@ interface MapPanelProps {
   query: string;
 }
 
-const DEFAULT_CENTER: [number, number] = [121.4737, 31.2304];
-const DEFAULT_MARKERS = [
-  [121.466, 31.236],
-  [121.48, 31.225],
-  [121.493, 31.238],
-  [121.455, 31.218],
-  [121.505, 31.22],
-  [121.445, 31.245],
-  [121.472, 31.252],
-  [121.515, 31.242],
-  [121.46, 31.204],
-  [121.488, 31.206],
-  [121.43, 31.227],
-  [121.525, 31.213],
-] as const;
-
+const DEFAULT_CENTER: [number, number] = [28.9784, 41.0082];
 export function MapPanel({
   restaurants,
   hoveredId,
@@ -50,19 +35,22 @@ export function MapPanel({
         zoom={12}
         cooperativeGestures
       >
-        {restaurants.map((restaurant, index) => {
-          const [fallbackLongitude, fallbackLatitude] =
-            DEFAULT_MARKERS[index % DEFAULT_MARKERS.length];
-          const longitude = restaurant.longitude ?? fallbackLongitude;
-          const latitude = restaurant.latitude ?? fallbackLatitude;
+        {restaurants.map((restaurant) => {
+          if (
+            restaurant.longitude === undefined ||
+            restaurant.latitude === undefined
+          ) {
+            return null;
+          }
+
           const isActive =
             hoveredId === restaurant.id || selectedId === restaurant.id;
 
           return (
             <MapMarker
               key={restaurant.id}
-              longitude={longitude}
-              latitude={latitude}
+              longitude={restaurant.longitude}
+              latitude={restaurant.latitude}
               onClick={() => onSelect(restaurant)}
               onMouseEnter={() => onHover(restaurant.id)}
               onMouseLeave={() => onHover(null)}

--- a/apps/web/src/app/restaurants/_components/restaurant-card.tsx
+++ b/apps/web/src/app/restaurants/_components/restaurant-card.tsx
@@ -9,7 +9,7 @@ import {
 } from '@remixicon/react';
 
 import {
-  getRestaurantCoverImage,
+  getRestaurantImageUrl,
   getRestaurantDistanceKm,
   getRestaurantIsOpen,
   type Restaurant,
@@ -20,7 +20,7 @@ type RestaurantCardProps = {
 };
 
 export function RestaurantCard({ restaurant }: RestaurantCardProps) {
-  const imageUrl = getRestaurantCoverImage(restaurant.slug);
+  const imageUrl = getRestaurantImageUrl(restaurant);
   const distanceKm = getRestaurantDistanceKm(restaurant.slug);
   const isOpen = getRestaurantIsOpen(restaurant.slug);
 

--- a/apps/web/src/app/restaurants/_components/restaurant-list-item.tsx
+++ b/apps/web/src/app/restaurants/_components/restaurant-list-item.tsx
@@ -8,7 +8,7 @@ import {
   RiTimeLine,
 } from '@remixicon/react';
 import {
-  getRestaurantCoverImage,
+  getRestaurantImageUrl,
   getRestaurantDistanceKm,
   getRestaurantIsOpen,
   type Restaurant,
@@ -29,7 +29,7 @@ export function RestaurantListItem({
   onLeave,
   onSelect,
 }: RestaurantListItemProps) {
-  const imageUrl = getRestaurantCoverImage(restaurant.slug);
+  const imageUrl = getRestaurantImageUrl(restaurant);
   const distanceKm = getRestaurantDistanceKm(restaurant.slug);
   const isOpen = getRestaurantIsOpen(restaurant.slug);
 

--- a/apps/web/src/app/restaurants/_components/search-bar.tsx
+++ b/apps/web/src/app/restaurants/_components/search-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { Button, Input } from 'ui-common';
 import { RiCloseLine, RiFilter3Line, RiSearchLine } from '@remixicon/react';
 
@@ -25,6 +25,10 @@ export function SearchBar({
 }: SearchBarProps) {
   const [inputValue, setInputValue] = useState(value);
 
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit(inputValue.trim());
@@ -36,21 +40,24 @@ export function SearchBar({
   };
 
   return (
-    <header className="relative z-30 flex shrink-0 items-center gap-2 border-b border-border/60 bg-background/95 px-3 py-2 backdrop-blur sm:px-4">
-      <form className="flex flex-1 items-center gap-2" onSubmit={handleSubmit}>
-        <div className="relative flex-1">
+    <form className="rounded-[1.25rem] border border-border/70 bg-background/92 p-3 shadow-xl shadow-black/5 backdrop-blur-xl" onSubmit={handleSubmit}>
+      <div className="flex items-center gap-2">
+        <div className="relative min-w-0 flex-1">
           <RiSearchLine className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              onChange(e.target.value);
+            }}
             placeholder="Search restaurants, cuisines, neighborhoods..."
-            className="h-10 rounded-full border-border/70 pl-9 pr-10 text-sm shadow-sm focus-visible:ring-1"
+            className="h-11 rounded-full border-border/70 pl-9 pr-10 text-sm shadow-sm focus-visible:ring-1"
           />
           {inputValue ? (
             <button
               type="button"
               onClick={handleClear}
-              className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-0.5 text-muted-foreground hover:text-foreground"
+              className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-0.5 text-muted-foreground transition hover:text-foreground"
             >
               <RiCloseLine className="size-4" />
             </button>
@@ -59,61 +66,32 @@ export function SearchBar({
 
         <Button
           type="button"
-          variant="outline"
+          variant={activeFilterCount > 0 ? 'default' : 'outline'}
           size="sm"
-          className={`relative h-10 rounded-full px-3 text-xs ${
-            activeFilterCount > 0
-              ? 'border-primary/50 bg-primary/5 text-primary'
-              : ''
-          }`}
+          className="relative h-11 rounded-full px-3 text-xs"
           onClick={onToggleFilters}
         >
           <RiFilter3Line className="size-4" />
           <span className="ml-1 hidden sm:inline">Filters</span>
           {activeFilterCount > 0 ? (
-            <span className="absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-full bg-primary text-[10px] text-primary-foreground">
+            <span className="absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-full bg-background text-[10px] font-semibold text-foreground">
               {activeFilterCount}
             </span>
           ) : null}
         </Button>
-      </form>
+      </div>
 
-      <Button
-        variant="outline"
-        size="sm"
-        className="h-10 rounded-full px-3 lg:hidden"
-        onClick={onToggleFilters}
-      >
-        {showFilters ? (
-          <svg
-            className="size-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        ) : (
-          <svg
-            className="size-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
-        )}
-      </Button>
-    </header>
+      <div className="mt-2 flex items-center justify-end lg:hidden">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-9 rounded-full px-3 text-xs"
+          onClick={onToggleFilters}
+        >
+          {showFilters ? 'Hide filters' : 'Show filters'}
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/apps/web/src/app/restaurants/_stores/explore-store.tsx
+++ b/apps/web/src/app/restaurants/_stores/explore-store.tsx
@@ -22,6 +22,7 @@ export type Restaurant = {
   review_count?: number;
   price_range?: string;
   category?: RestaurantCategory;
+  primary_photo_url?: string;
 };
 
 export type PaginationMeta = {

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -22,6 +22,7 @@ export type Restaurant = {
   review_count?: number;
   price_range?: string;
   category?: RestaurantCategory;
+  primary_photo_url?: string;
 };
 
 export type User = {
@@ -160,6 +161,7 @@ export async function fetchRestaurantDetail(
     review_count: toNumber(payload.data.review_count),
     price_range: payload.data.price_range,
     category: payload.data.category,
+    primary_photo_url: resolveApiAssetUrl(payload.data.primary_photo_url),
   };
 }
 
@@ -252,6 +254,28 @@ export function getRestaurantIsOpen(seed: string): boolean {
   return hash % 4 !== 0;
 }
 
+export function getRestaurantImageUrl(
+  restaurant: Pick<Restaurant, 'slug' | 'primary_photo_url'>,
+): string {
+  return (
+    resolveApiAssetUrl(restaurant.primary_photo_url) ||
+    getRestaurantCoverImage(restaurant.slug)
+  );
+}
+
+export function resolveApiAssetUrl(url?: string | null): string {
+  const normalizedUrl = url?.trim();
+  if (!normalizedUrl) {
+    return '';
+  }
+
+  if (/^https?:\/\//i.test(normalizedUrl) || normalizedUrl.startsWith('data:')) {
+    return normalizedUrl;
+  }
+
+  return new URL(normalizedUrl, getApiBaseUrl()).toString();
+}
+
 function seededHash(seed: string): number {
   let hash = 0;
   for (let index = 0; index < seed.length; index += 1) {
@@ -283,6 +307,7 @@ function normalizeRestaurant(
     review_count: toNumber(candidate.review_count),
     price_range: candidate.price_range,
     category: candidate.category,
+    primary_photo_url: resolveApiAssetUrl(candidate.primary_photo_url),
   };
 }
 


### PR DESCRIPTION
## Summary
- Add primary photo upload support to restaurant create/update flows in the Django API.
- Expose primary photo URLs in restaurant responses and wire the owner dashboard and explore views to use them.
- Update the restaurant UI, auth shell, and navigation to support the photo-aware experience.

Closes #17